### PR TITLE
Ignore 'genBasic' 'devChange' event for Cube

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -185,7 +185,7 @@ const devices = [
         supports: 'shake, wakeup, fall, tap, slide, flip180, flip90, rotate_left and rotate_right',
         fromZigbee: [
             fz.xiaomi_battery_3v, fz.MFKZQ01LM_action_multistate, fz.MFKZQ01LM_action_analog,
-            fz.ignore_analog_change, fz.ignore_multistate_change,
+            fz.ignore_analog_change, fz.ignore_multistate_change, fz.ignore_basic_change,
         ],
         toZigbee: [],
     },


### PR DESCRIPTION
Sometimes cube generate 'devChange' events, like here https://community.home-assistant.io/t/zigbee2mqtt-getting-rid-of-your-proprietary-zigbee-bridges-xiaomi-hue-tradfri/52108/180

Suppress them.