### PR TITLE
Add support for Gledopto RGB+CCT ZLL controller

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -866,6 +866,17 @@ const devices = [
         fromZigbee: generic.light_onoff_brightness().fromZigbee,
         toZigbee: generic.light_onoff_brightness().toZigbee,
     },
+
+    // Gledopto
+    {
+        zigbeeModel: ['GLEDOPTO'],
+        model: 'GL-C-008',
+        vendor: 'Gledopto',
+        description: '2.4G Wireless RGB+CCT LED Controller - ZigBee Light Link Compatible',
+        supports: generic.light_onoff_brightness_colortemp_colorxy().supports,
+        fromZigbee: generic.light_onoff_brightness_colortemp_colorxy().fromZigbee,
+        toZigbee: generic.light_onoff_brightness_colortemp_colorxy().toZigbee,
+    },
 ];
 
 module.exports = devices;

--- a/devices.js
+++ b/devices.js
@@ -872,7 +872,7 @@ const devices = [
         zigbeeModel: ['GLEDOPTO'],
         model: 'GL-C-008',
         vendor: 'Gledopto',
-        description: '2.4G Wireless RGB+CCT LED Controller - ZigBee Light Link Compatible',
+        description: 'Zigbee LED controller RGB + CCT',
         supports: generic.light_onoff_brightness_colortemp_colorxy().supports,
         fromZigbee: generic.light_onoff_brightness_colortemp_colorxy().fromZigbee,
         toZigbee: generic.light_onoff_brightness_colortemp_colorxy().toZigbee,


### PR DESCRIPTION
This adds support for the Gledopto RGB+CCT ZLL controller (https://www.aliexpress.com/store/product/GLEDOPTO-ZIGBEE-Led-Controller-RGB-CCT-WW-CW-zigbee-controller-LED-DC12-24V-LED-strip-controller/3685003_32858603964.html?spm=2114.12010608.0.0.610464c4mrUi3T)

I only have these controllers, so I haven't been able to test with the RGBW version, or the RGB version.