### PR TITLE
Add OSRAM SMART+ CLASSIC A 60 TW

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -598,6 +598,15 @@ const devices = [
         toZigbee: generic.light_onoff_brightness_colortemp_colorxy().toZigbee,
     },
     {
+        zigbeeModel: ['CLA60 TW OSRAM'],
+        model: 'AC03642',
+        vendor: 'OSRAM',
+        description: 'SMART+ CLASSIC A 60 TW',
+        supports: generic.light_onoff_brightness_colortemp().supports,
+        fromZigbee: generic.light_onoff_brightness_colortemp().fromZigbee,
+        toZigbee: generic.light_onoff_brightness_colortemp().toZigbee,
+    },
+    {
         // AA70155 is model number of both bulbs.
         zigbeeModel: ['LIGHTIFY A19 Tunable White', 'Classic A60 TW'],
         model: 'AA70155',


### PR DESCRIPTION
LEDVANCE variant of Classic A60 TW

More info: https://www.osram-lamps.com/ecatalog/smart-home/smart-home-lamps/led-lamps-classic-bulb-shape/smart-classic-a-60-tw/index.jsp

Mine had barcode 4058075816534 on the box and AC03642 on the bulb.