### PR TITLE
Fix WXKG03LM devChange Converter Message

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -104,7 +104,7 @@ const devices = [
         vendor: 'Xiaomi',
         description: 'Aqara single key wireless wall switch',
         supports: 'single click',
-        fromZigbee: [fz.xiaomi_battery_3v, fz.WXKG03LM_click, fz.ignore_onoff_change],
+        fromZigbee: [fz.xiaomi_battery_3v, fz.WXKG03LM_click, fz.ignore_basic_change],
         toZigbee: [],
     },
     {

--- a/devices.js
+++ b/devices.js
@@ -104,7 +104,7 @@ const devices = [
         vendor: 'Xiaomi',
         description: 'Aqara single key wireless wall switch',
         supports: 'single click',
-        fromZigbee: [fz.xiaomi_battery_3v, fz.WXKG03LM_click],
+        fromZigbee: [fz.xiaomi_battery_3v, fz.WXKG03LM_click, fz.ignore_onoff_change],
         toZigbee: [],
     },
     {


### PR DESCRIPTION
This fix the upcoming messages:

```
2018-8-8 13:27:31 DEBUG Recieved zigbee message with data {"cid":"genBasic","data":{"65281":[null,3115,null,29,5032,75,[2,16777218],null,5125,null,0]}}
2018-8-8 13:27:31 WARN No converter available for 'WXKG03LM' with cid 'genBasic', type 'devChange' and data '{"cid":"genBasic","data":{"65281":[null,3115,null,29,5032,75,[2,16777218],null,5125,null,0]}}'
2018-8-8 13:27:31 WARN Please see: https://github.com/Koenkk/zigbee2mqtt/wiki/How-to-support-new-devices.
2018-8-8 13:27:31 DEBUG Recieved zigbee message with data {"cid":"genBasic","data":{"65281":[null,3055,null,26,5032,53,[0,65538],null,null,null,0]}}
2018-8-8 13:27:31 WARN No converter available for 'WXKG03LM' with cid 'genBasic', type 'devChange' and data '{"cid":"genBasic","data":{"65281":[null,3055,null,26,5032,53,[0,65538],null,null,null,0]}}'
2018-8-8 13:27:31 WARN Please see: https://github.com/Koenkk/zigbee2mqtt/wiki/How-to-support-new-devices.
```