### PR TITLE
add support for Sengled Element Touch (A19)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -934,6 +934,15 @@ const devices = [
         fromZigbee: generic.light_onoff_brightness().fromZigbee,
         toZigbee: generic.light_onoff_brightness().toZigbee,
     },
+    {
+        zigbeeModel: ['Z01-CIA19NAE26'],
+        model: 'Z01-CIA19NAE26',
+        vendor: 'Sengled',
+        description: 'Element Touch (A19)',
+        supports: generic.light_onoff_brightness().supports,
+        fromZigbee: generic.light_onoff_brightness().fromZigbee,
+        toZigbee: generic.light_onoff_brightness().toZigbee,
+    },
 
     // JIAWEN
     {


### PR DESCRIPTION
Some info is available on the [product page](https://us.sengled.com/products/element-touch).
The color temperature changes in tandem with the brightness and is not adjustable separately.