### PR TITLE
Add support for Sylvania Smart+ bulb model 74283

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -885,6 +885,15 @@ const devices = [
         toZigbee: generic.light_onoff_brightness_colortemp_colorxy().toZigbee,
     },
     {
+        zigbeeModel: ['LIGHTIFY A19 ON/OFF/DIM'],
+        model: '74283',
+        vendor: 'Sylvania',
+        description: 'LIGHTIFY A19 ON/OFF/DIM',
+        supports: generic.light_onoff_brightness().supports,
+        fromZigbee: generic.light_onoff_brightness().fromZigbee,
+        toZigbee: generic.light_onoff_brightness().toZigbee,
+    },
+    {
         zigbeeModel: ['PLUG'],
         model: '72922-A',
         vendor: 'Sylvania',


### PR DESCRIPTION
Sylvania Smart+ bulb model 74283 ulb supports on/off/brightness. 

This one: https://www.amazon.com/gp/product/B0727WZ3L2/ref=oh_aui_detailpage_o00_s00?ie=UTF8&psc=1