### PR TITLE
Fix brightness command being dropped when turning on bulbs

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -74,7 +74,7 @@ const converters = {
         convert: (value, message) => {
             return {
                 cid: 'genLevelCtrl',
-                cmd: 'moveToLevel',
+                cmd: 'moveToLevelWithOnOff',
                 type: 'functional',
                 zclData: {
                     level: value,

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -70,7 +70,7 @@ const converters = {
     },
     light_brightness: {
         key: 'brightness',
-        attr: ['currentLevel'],
+        attr: ['currentLevel', 'onOff'],
         convert: (value, message) => {
             return {
                 cid: 'genLevelCtrl',


### PR DESCRIPTION
Likely fixes https://github.com/Koenkk/zigbee2mqtt/issues/321, as I had a similar issue with my Sengled E11-G13 devices where when issuing a single "turn on w/ brightness" command from Home assistant the brightness setting wasn't respected.

The reason I found when debugging is that that command is split into two separate zigbee commands arbitrarily ordered based on the keys of the mqtt object received. What this resulted in was that command being separated into a `moveToLevel` command first, with the `genOnOff` happening afterwards. This could be seen in the logs here:

```
2018-9-23 05:21:46 - info: Zigbee publish to '0xb0ce181403349cfc', genLevelCtrl - moveToLevel - {"level":2,"transtime":0} - null
2018-9-23 05:21:46 - info: Zigbee publish to '0xb0ce181403349cfc', genOnOff - on - {} - null
2018-9-23 05:21:46 - info: Zigbee publish to '0xb0ce18140334b0ab', genLevelCtrl - moveToLevel - {"level":2,"transtime":0} - null
2018-9-23 05:21:46 - info: Zigbee publish to '0xb0ce18140334b0ab', genOnOff - on - {} - null
2018-9-23 05:21:46 - info: Zigbee publish to '0xb0ce181403364149', genLevelCtrl - moveToLevel - {"level":2,"transtime":0} - null
2018-9-23 05:21:46 - info: Zigbee publish to '0xb0ce181403364149', genOnOff - on - {} - null
2018-9-23 05:21:46 - info: MQTT publish, topic: 'zigbee2mqtt/0xb0ce181403349cfc', payload: '{"state":"ON","brightness":255}'
2018-9-23 05:21:46 - info: MQTT publish, topic: 'zigbee2mqtt/0xb0ce18140334b0ab', payload: '{"state":"ON","brightness":255}'
2018-9-23 05:21:47 - info: MQTT publish, topic: 'zigbee2mqtt/0xb0ce181403364149', payload: '{"state":"ON","brightness":255}'
2018-9-23 05:21:47 - info: MQTT publish, topic: 'zigbee2mqtt/0xb0ce181403349cfc', payload: '{"state":"ON","brightness":255}'
2018-9-23 05:21:47 - info: MQTT publish, topic: 'zigbee2mqtt/0xb0ce18140334b0ab', payload: '{"state":"ON","brightness":255}'
2018-9-23 05:21:47 - info: MQTT publish, topic: 'zigbee2mqtt/0xb0ce181403364149', payload: '{"state":"ON","brightness":255}'
```

Not sure why exactly this would cause the sengled bulb to not work as I believe you should be able to change brightness regardless of the device being on, but as you can see from the responses the level of 1 is never correctly set in the bulbs themselves.

Simply replacing the `moveToLevel` with a `moveToLevelWithOnOff` seen here https://github.com/zigbeer/zcl-packet/wiki/6.-Appendix#621-general caused my devices to have the expected behavior of starting up with the indicated brightness without any flickering.

The main issue is if people need to change brightness without turning on the device, but without a more rewrite of the logic in how mqtt commands are parsed into zigbee commands, i'm not sure it's cleanly possible.