### PR TITLE
Support for Aqara Cube firmware 20180815 model name

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -247,7 +247,7 @@ const devices = [
         toZigbee: [],
     },
     {
-        zigbeeModel: ['lumi.sensor_cube'],
+        zigbeeModel: ['lumi.sensor_cube', '0x656275635f726f736e65732e696d756c'],
         model: 'MFKZQ01LM',
         vendor: 'Xiaomi',
         description: 'Mi smart home cube',


### PR DESCRIPTION
In the latest Aqara Cube firmware the model id is reported as '0x656275635f726f736e65732e696d756c' which corresponds to 'ebuc_rosnes.imul' in ascii. This PR adds support for this (buggy?) model id.

Fixes https://github.com/Koenkk/zigbee2mqtt/issues/388