### PR TITLE
Added Support for new WXKG11LM Model

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -284,6 +284,21 @@ const converters = {
             return lookup[value] ? lookup[value] : null;
         },
     },
+    WXKG11LM_action_click_multistate: {
+        cid: 'genMultistateInput',
+        type: 'attReport',
+        convert: (model, msg, publish, options) => {
+            const value = msg.data.data['presentValue'];
+            const lookup = {
+                1: {click: 'single'}, // single click
+                2: {click: 'double'}, // double click
+                0: {action: 'hold'}, // hold for more than 400ms
+                255: {action: 'release'}, // release after hold for more than 400ms
+            };
+
+            return lookup[value] ? lookup[value] : null;
+        },
+    },
     xiaomi_humidity: {
         cid: 'msRelativeHumidity',
         type: 'attReport',

--- a/devices.js
+++ b/devices.js
@@ -88,18 +88,6 @@ const devices = [
         toZigbee: [],
     },
     {
-        zigbeeModel: ['lumi.sensor_switch.aq3', 'lumi.sensor_swit'],
-        model: 'WXKG12LM',
-        vendor: 'Xiaomi',
-        description: 'Aqara wireless switch (with gyroscope)',
-        supports: 'single, double, shake, hold, release',
-        fromZigbee: [
-            fz.xiaomi_battery_3v, fz.WXKG12LM_action_click_multistate, fz.ignore_onoff_change,
-            fz.ignore_basic_change, fz.ignore_multistate_change,
-        ],
-        toZigbee: [],
-    },
-    {
         zigbeeModel: ['lumi.remote.b1acn01\u0000\u0000\u0000\u0000\u0000\u0000'],
         model: 'WXKG11LM',
         vendor: 'Xiaomi',
@@ -108,6 +96,18 @@ const devices = [
         fromZigbee: [
             fz.xiaomi_battery_3v, fz.WXKG11LM_action_click_multistate, fz.ignore_onoff_change,
             fz.ignore_basic_change, fz.ignore_multistate_change
+        ],
+        toZigbee: [],
+    },
+    {
+        zigbeeModel: ['lumi.sensor_switch.aq3', 'lumi.sensor_swit'],
+        model: 'WXKG12LM',
+        vendor: 'Xiaomi',
+        description: 'Aqara wireless switch (with gyroscope)',
+        supports: 'single, double, shake, hold, release',
+        fromZigbee: [
+            fz.xiaomi_battery_3v, fz.WXKG12LM_action_click_multistate, fz.ignore_onoff_change,
+            fz.ignore_basic_change, fz.ignore_multistate_change,
         ],
         toZigbee: [],
     },

--- a/devices.js
+++ b/devices.js
@@ -100,6 +100,18 @@ const devices = [
         toZigbee: [],
     },
     {
+        zigbeeModel: ['lumi.remote.b1acn01\u0000\u0000\u0000\u0000\u0000\u0000'],
+        model: 'WXKG11LM',
+        vendor: 'Xiaomi',
+        description: 'Aqara wireless switch',
+        supports: 'single, double, hold, release',
+        fromZigbee: [
+            fz.xiaomi_battery_3v, fz.WXKG11LM_action_click_multistate, fz.ignore_onoff_change,
+            fz.ignore_basic_change, fz.ignore_multistate_change
+        ],
+        toZigbee: [],
+    },
+    {
         zigbeeModel: ['lumi.sensor_86sw1\u0000lu'],
         model: 'WXKG03LM',
         vendor: 'Xiaomi',

--- a/devices.js
+++ b/devices.js
@@ -79,23 +79,14 @@ const devices = [
         toZigbee: [],
     },
     {
-        zigbeeModel: ['lumi.sensor_switch.aq2'],
+        zigbeeModel: ['lumi.sensor_switch.aq2', 'lumi.remote.b1acn01\u0000\u0000\u0000\u0000\u0000\u0000'],
         model: 'WXKG11LM',
         vendor: 'Xiaomi',
         description: 'Aqara wireless switch',
-        supports: 'single, double, triple, quadruple click',
-        fromZigbee: [fz.xiaomi_battery_3v, fz.WXKG11LM_click, fz.ignore_onoff_change, fz.ignore_basic_change],
-        toZigbee: [],
-    },
-    {
-        zigbeeModel: ['lumi.remote.b1acn01\u0000\u0000\u0000\u0000\u0000\u0000'],
-        model: 'WXKG11LM',
-        vendor: 'Xiaomi',
-        description: 'Aqara wireless switch',
-        supports: 'single, double, hold, release',
+        supports: 'single, double click (and triple, quadruple, hold, release depending on model)',
         fromZigbee: [
-            fz.xiaomi_battery_3v, fz.WXKG11LM_action_click_multistate, fz.ignore_onoff_change,
-            fz.ignore_basic_change, fz.ignore_multistate_change
+            fz.xiaomi_battery_3v, fz.WXKG11LM_click, fz.ignore_onoff_change, fz.ignore_basic_change,
+            fz.WXKG11LM_action_click_multistate, fz.ignore_multistate_change,
         ],
         toZigbee: [],
     },


### PR DESCRIPTION
Added Support for New WXKG11LM (Xiaomi Aqara wireless switch). This model has hold & release functionality instead of the quad-click implementation. 

The Zigbee model name has 6 null unicode characters trailing after its ID.


