### PR TITLE
Update CLA60 RGBW OSRAM 

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -735,7 +735,7 @@ const devices = [
     },
     {
         zigbeeModel: ['CLA60 RGBW OSRAM'],
-        model: 'AC03845',
+        model: 'AC03645',
         vendor: 'OSRAM',
         description: 'LIGHTIFY LED CLA60 E27 RGBW',
         supports: generic.light_onoff_brightness_colortemp_colorxy().supports,


### PR DESCRIPTION
Please change that number since I must have misstyped it when making the original pr to add this device. It does only work with 'AC03645'.