### PR TITLE
Add Nue Double GPO (au version)

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -877,7 +877,7 @@ const converters = {
         cid: 'genOnOff',
         type: 'attReport',
         convert: (model, msg, publish, options) => {
-            const button = getKey(model.ep, msg.endpoints[0].epId)
+            const button = getKey(model.ep, msg.endpoints[0].epId);
             if (button) {
                 const payload = {};
                 payload[`state_${button}`] = msg.data.data['onOff'] === 1 ? 'ON' : 'OFF';

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -877,11 +877,10 @@ const converters = {
         cid: 'genOnOff',
         type: 'attReport',
         convert: (model, msg, publish, options) => {
-            const mapping = {12: 'left', 11: 'right'};
-            const whichButton = mapping[msg.endpoints[0].epId];
-            if (whichButton) {
+            const button = getKey(model.ep, msg.endpoints[0].epId)
+            if (button) {
                 const payload = {};
-                payload[`state_${whichButton}`] = msg.data.data['onOff'] === 1 ? 'ON' : 'OFF';
+                payload[`state_${button}`] = msg.data.data['onOff'] === 1 ? 'ON' : 'OFF';
                 return payload;
             }
         },

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -873,7 +873,20 @@ const converters = {
             return {power: msg.data.data['activePower'] / 10.0};
         },
     },
-
+    nue_power_state: {
+        cid: 'genOnOff',
+        type: 'attReport',
+        convert: (model, msg, publish, options) => {
+            const mapping = {12: 'left', 11: 'right'};
+            const whichButton = mapping[msg.endpoints[0].epId];
+            if (whichButton) {
+                const payload = {};
+                payload[`state_${whichButton}`] = msg.data.data['onOff'] === 1 ? 'ON' : 'OFF';
+                return payload;
+            }
+        },
+    },
+    
     // Ignore converters (these message dont need parsing).
     ignore_doorlock_change: {
         cid: 'closuresDoorLock',

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -886,7 +886,7 @@ const converters = {
             }
         },
     },
-    
+
     // Ignore converters (these message dont need parsing).
     ignore_doorlock_change: {
         cid: 'closuresDoorLock',

--- a/devices.js
+++ b/devices.js
@@ -1253,7 +1253,7 @@ const devices = [
         toZigbee: [tz.onoff],
     },
     {
-        zigbeeModel: ['FNB56-SKT1DHG1.44'],
+        zigbeeModel: ['FNB56-SKT1DHG1.4'],
         model: 'MG-AUWS01',
         vendor: 'Nue',
         description: 'ZigBee Double GPO',

--- a/devices.js
+++ b/devices.js
@@ -1260,7 +1260,7 @@ const devices = [
         supports: 'on/off',
         fromZigbee: [fz.nue_power_state, fz.ignore_onoff_change],
         toZigbee: [tz.onoff],
-        ep: {'left': 12, 'right': 11}     
+        ep: {'left': 12, 'right': 11},
     },
 
     // Gledopto

--- a/devices.js
+++ b/devices.js
@@ -1252,6 +1252,16 @@ const devices = [
         fromZigbee: [fz.generic_state],
         toZigbee: [tz.onoff],
     },
+    {
+        zigbeeModel: ['0x342e3147484431544b532d3635424e46'],
+        model: 'MG-AUWS01',
+        vendor: 'Nue',
+        description: 'ZigBee double power point',
+        supports: 'on/off',
+        fromZigbee: [fz.nue_power_state, fz.ignore_onoff_change],
+        toZigbee: [tz.onoff],
+        ep: {'left': 12, 'right': 11}     
+    },
 
     // Gledopto
     {

--- a/devices.js
+++ b/devices.js
@@ -1253,7 +1253,7 @@ const devices = [
         toZigbee: [tz.onoff],
     },
     {
-        zigbeeModel: ['FNB56-SKT1DHG1.4'],
+        zigbeeModel: ['FNB56-SKT1DHG1.44'],
         model: 'MG-AUWS01',
         vendor: 'Nue',
         description: 'ZigBee Double GPO',

--- a/devices.js
+++ b/devices.js
@@ -1253,7 +1253,7 @@ const devices = [
         toZigbee: [tz.onoff],
     },
     {
-        zigbeeModel: ['0x342e3147484431544b532d3635424e46'],
+        zigbeeModel: ['FNB56-SKT1DHG1.4'],
         model: 'MG-AUWS01',
         vendor: 'Nue',
         description: 'ZigBee Double GPO',

--- a/devices.js
+++ b/devices.js
@@ -1256,7 +1256,7 @@ const devices = [
         zigbeeModel: ['0x342e3147484431544b532d3635424e46'],
         model: 'MG-AUWS01',
         vendor: 'Nue',
-        description: 'ZigBee double power point',
+        description: 'ZigBee Double GPO',
         supports: 'on/off',
         fromZigbee: [fz.nue_power_state, fz.ignore_onoff_change],
         toZigbee: [tz.onoff],


### PR DESCRIPTION
Hi.  I've added the code to connect the AU version of the Neu Double Power Outlet (https://www.amazon.com.au/Approved-Standard-Nue-SmartThings-Automation/dp/B07GX943VP/ref=sr_1_15?ie=UTF8&qid=1538269827&sr=8-15&keywords=nue+zigbee).  This is my first ever pull request so if I've messed it up please let me know.  Thanks, Patrick