### PR TITLE
Support for Innr 285C RGBW bulb

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -961,6 +961,15 @@ const devices = [
         toZigbee: generic.light_onoff_brightness_colortemp_colorxy().toZigbee,
     },
     {
+        zigbeeModel: ['RB 285 C'],
+        model: 'RB 285 C',
+        vendor: 'Innr',
+        description: 'E27 Bulb RGBW',
+        supports: generic.light_onoff_brightness_colortemp_colorxy().supports,
+        fromZigbee: generic.light_onoff_brightness_colortemp_colorxy().fromZigbee,
+        toZigbee: generic.light_onoff_brightness_colortemp_colorxy().toZigbee,
+    },
+    {
         zigbeeModel: ['RB 165'],
         model: 'RB 165',
         vendor: 'Innr',


### PR DESCRIPTION
Added support for Innr 285C, tested all functions locally in HomeAssistant (On/Off/Colour/White Temperature) and working with generic functions used by the already supported Innr RGBW bulb (185C).

Bulb is an E27 bulb listed on Amazon UK here - https://www.amazon.co.uk/Innr-Colour-Philips-Assistant-Required/dp/B07GT1LWDH/ref=sr_1_1?ie=UTF8&qid=1541855612&sr=8-1&keywords=innr+285c