### PR TITLE
Added support for LTC015

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -633,6 +633,15 @@ const devices = [
         fromZigbee: generic.light_onoff_brightness_colortemp().fromZigbee,
         toZigbee: generic.light_onoff_brightness_colortemp().toZigbee,
     },
+    {     
+        zigbeeModel: ['LTC015'],
+        model: '3216331P5',                   
+        vendor: 'Philips',
+        description: 'Philips Hue White ambiance Aurelle Rectangle Panel Light',
+        supports: generic.light_onoff_brightness_colortemp().supports,                  
+        fromZigbee: generic.light_onoff_brightness_colortemp().fromZigbee,                  
+        toZigbee: generic.light_onoff_brightness_colortemp().toZigbee,
+    },
     {
         zigbeeModel: ['LLC010'],
         model: '7199960PH',

--- a/devices.js
+++ b/devices.js
@@ -633,13 +633,13 @@ const devices = [
         fromZigbee: generic.light_onoff_brightness_colortemp().fromZigbee,
         toZigbee: generic.light_onoff_brightness_colortemp().toZigbee,
     },
-    {     
+    {
         zigbeeModel: ['LTC015'],
-        model: '3216331P5',                   
+        model: '3216331P5',
         vendor: 'Philips',
         description: 'Philips Hue White ambiance Aurelle Rectangle Panel Light',
-        supports: generic.light_onoff_brightness_colortemp().supports,                  
-        fromZigbee: generic.light_onoff_brightness_colortemp().fromZigbee,                  
+        supports: generic.light_onoff_brightness_colortemp().supports,
+        fromZigbee: generic.light_onoff_brightness_colortemp().fromZigbee,
         toZigbee: generic.light_onoff_brightness_colortemp().toZigbee,
     },
     {


### PR DESCRIPTION
Philips Hue White ambiance Aurelle Rectangle Panel Light ([https://www.p4c.philips.com/files/3/3216331p5/3216331p5_pss_.pdf](https://www.p4c.philips.com/files/3/3216331p5/3216331p5_pss_.pdf))