### PR TITLE
fix(xiaomi_lock_report): improve conversion of key error messages

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -644,9 +644,15 @@ const converters = {
                 const state = data.substr(2, 2);
                 const action = data.substr(4, 2);
                 const keynum = data.substr(6, 2);
-                if (state == 11 && action == 7) {
-                    // wrong key or not success inserted
-                    return {keyerror: true};
+                if (state == 11) {
+                    if (action == 1) {
+                        // unknown key
+                        return {keyerror: true, inserted: 'unknown'};
+                    }
+                    if (action == 3) {
+                        // explicitly disabled key (e.g.: reported lost)
+                        return {keyerror: true, inserted: keynum};
+                    }
                 }
                 if (state == 12) {
                     if (action == 1) {


### PR DESCRIPTION
This PR improves conversion of key error messages so that they are properly returned.

It also makes a distinction between unknown keys (not registered) and disabled keys (explicitly disabled through Mi Home).

Seeing that @kirovilya originally added support for this lock, I suppose he should be able to review this PR and check if it works for him.

Fix #135