### PR TITLE
fix(xiaomi_lock_report): clear keyerror and forgotten after successful unlock

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -643,10 +643,12 @@ const converters = {
                 }
                 if (state == 12) {
                     if (action == 1) {
-                        return {inserted: keynum};
+                        // successful unlock, sets everything to neutral state
+                        return {inserted: keynum, keyerror: false, forgotten: false};
                     }
                     if (action == 11) {
-                        return {forgotten: keynum};
+                        // forgot the key in the lock
+                        return {forgotten: keynum, keyerror: false};
                     }
                 }
             }


### PR DESCRIPTION
This clears `keyerror` and `forgotten` attributes after a successful unlock of the Vima Smart Lock so that those attributes are not cached as `true` forever. (Otherwise, they are useless).

It also adds some comments to better describe the different `action`s.

Fix #136