### PR TITLE
Add support for sengled Element Plus (A19)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1254,6 +1254,15 @@ const devices = [
     },
 
     // Sengled
+     {
+        zigbeeModel: ['Z01-A19NAE26'],
+        model: 'Z01-A19NAE26',
+        vendor: 'Sengled',
+        description: 'Element Plus (A19)',
+        supports: generic.light_onoff_brightness_colortemp().supports,
+        fromZigbee: generic.light_onoff_brightness_colortemp().fromZigbee,
+        toZigbee: generic.light_onoff_brightness_colortemp().toZigbee,
+    },
     {
         zigbeeModel: ['E11-G13'],
         model: 'E11-G13',

--- a/devices.js
+++ b/devices.js
@@ -1254,15 +1254,6 @@ const devices = [
     },
 
     // Sengled
-     {
-        zigbeeModel: ['Z01-A19NAE26'],
-        model: 'Z01-A19NAE26',
-        vendor: 'Sengled',
-        description: 'Element Plus (A19)',
-        supports: generic.light_onoff_brightness_colortemp().supports,
-        fromZigbee: generic.light_onoff_brightness_colortemp().fromZigbee,
-        toZigbee: generic.light_onoff_brightness_colortemp().toZigbee,
-    },
     {
         zigbeeModel: ['E11-G13'],
         model: 'E11-G13',
@@ -1289,6 +1280,15 @@ const devices = [
         supports: generic.light_onoff_brightness().supports,
         fromZigbee: generic.light_onoff_brightness().fromZigbee,
         toZigbee: generic.light_onoff_brightness().toZigbee,
+    },
+    {
+        zigbeeModel: ['Z01-A19NAE26'],
+        model: 'Z01-A19NAE26',
+        vendor: 'Sengled',
+        description: 'Element Plus (A19)',
+        supports: generic.light_onoff_brightness_colortemp().supports,
+        fromZigbee: generic.light_onoff_brightness_colortemp().fromZigbee,
+        toZigbee: generic.light_onoff_brightness_colortemp().toZigbee,
     },
     {
         zigbeeModel: ['E11-N1EA'],


### PR DESCRIPTION
All features of the bulb work using the "generic.light_onoff_brightness_colortemp" converter. More info about the bulb can be found here - https://www.amazon.com/Sengled-2700-6500K-Equivalent-Assistant-SmartThings/dp/B01MQVYNFL