### PR TITLE
Add initial OSRAM Smart+ Motion Sensor support

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -971,6 +971,34 @@ const converters = {
             };
         },
     },
+    ias_zone_motion_dev_change: {
+        cid: 'ssIasZone',
+        type: 'devChange',
+        convert: (model, msg, publish, options) => {
+            //console.log(msg);
+            if (msg.data.data.zoneType === 0x000D) { // type 0x000D = motion sensor
+                const zoneStatus = msg.data.data.zoneStatus;
+                return {
+                    occupancy:   (zoneStatus & 1<<1) > 0,  // Bit 1 = Alarm 2: Presence Indication
+                    tamper:      (zoneStatus & 1<<2) > 0,  // Bit 2 = Tamper status
+                    battery_low: (zoneStatus & 1<<3) > 0,  // Bit 3 = Battery LOW indicator (trips around 2.4V)
+                };
+            }
+        },
+    },
+   ias_zone_motion_status_change: {
+        cid: 'ssIasZone',
+        type: 'statusChange',
+        convert: (model, msg, publish, options) => {
+            //console.log(msg);
+            const zoneStatus = msg.data.zoneStatus;
+            return {
+                occupancy:   (zoneStatus & 1<<1) > 0,  // Bit 1 = Alarm 2: Presence Indication
+                tamper:      (zoneStatus & 1<<2) > 0,  // Bit 2 = Tamper status
+                battery_low: (zoneStatus & 1<<3) > 0,  // Bit 3 = Battery LOW indicator (trips around 2.4V)
+            };
+        },
+    },
 
     // Ignore converters (these message dont need parsing).
     ignore_doorlock_change: {

--- a/devices.js
+++ b/devices.js
@@ -1586,6 +1586,29 @@ const devices = [
             execute(device, actions, callback, 1000);
         },
     },
+
+    // OSRAM Smart, Motion Sensor
+    {
+        zigbeeModel: ['Motion Sensor-A'],
+        model: 'AC01353010G',
+        vendor: 'OSRAM LEDVANCE',
+        description: 'SMART+ Motion Sensor ',
+        supports: 'occupancy and temperature',
+        fromZigbee: [fz.generic_temperature, fz.ignore_temperature_change, fz.ias_zone_motion_dev_change, fz.ias_zone_motion_status_change],
+        toZigbee: [],
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const device = shepherd.find(ieeeAddr, 1);
+            const actions = [
+                (cb) => device.write('ssIasZone', 'iasCieAddr', coordinator.device.getIeeeAddr(), cb),
+                (cb) => device.functional('ssIasZone', 'enrollRsp', {enrollrspcode: 0, zoneid: 23}, cb),
+                (cb) => device.bind('msTemperatureMeasurement', coordinator, cb),
+                (cb) => device.report('msTemperatureMeasurement', 'measuredValue', 30, 600, 1, cb),
+                (cb) => device.bind('genPowerCfg', coordinator, cb),
+                (cb) => device.report('genPowerCfg', 'batteryPercentageRemaining', 0, 1000, 0, cb),
+            ];
+            execute(device, actions, callback);
+        },
+    },
 ];
 
 module.exports = devices;


### PR DESCRIPTION
Add zigbeeModel ['Motion Sensor-A'] with converters 'ias_zone_motion_dev_change' and 'ias_zone_motion_status_change'.
Note: genPowerCfg maybe not working!

See Issue: https://github.com/Koenkk/zigbee2mqtt/issues/507

Co-Authored-By: Koen Kanters <koenkk@users.noreply.github.com>