### PR TITLE
Include color mode (xy or colortemp) for hue rgbw bulbs

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -440,6 +440,10 @@ const converters = {
             if (msg.data.data['colorTemperature']) {
                 result.color_temp = msg.data.data['colorTemperature'];
             }
+            
+            if (msg.data.data['colorMode']) {
+                result.color_mode = msg.data.data['colorMode'];
+            }
 
             if (msg.data.data['currentX'] || msg.data.data['currentY']) {
                 result.color = {};

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -440,7 +440,7 @@ const converters = {
             if (msg.data.data['colorTemperature']) {
                 result.color_temp = msg.data.data['colorTemperature'];
             }
-            
+
             if (msg.data.data['colorMode']) {
                 result.color_mode = msg.data.data['colorMode'];
             }


### PR DESCRIPTION
The color mode can be used by home automation to determine the correct way to (re)calculate the set lighting. Zigbee2mqtt plugin for Domoticz will use the acknowledged info to correctly set the sliders (rgb/colortemp) in the UI and database. (my upcoming addition to the plugin to support HUE white and ambiance bulbs will use it)
The hue bulb will only update this value after a color mode change, but it will be cached by MQTT.