### PR TITLE
Added light blinking (Hue style 'alert') feature

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -163,6 +163,29 @@ const converters = {
             }
         },
     },
+    light_alert: {
+        key: 'alert',
+        convert: (value, message, type) => {
+            const cid = 'genIdentify';
+            if (type === 'set') {
+                const lookup = {
+                    'select': 0x00,
+                    'lselect': 0x01,
+                    'none': 0xFF,
+                };
+                return {
+                    cid: cid,
+                    cmd: 'triggerEffect',
+                    cmdType: 'functional',
+                    zclData: {
+                        effectid: lookup[value.toLowerCase()],
+                        effectvariant: 0x01,
+                    },
+                    cfg: cfg.default,
+                };
+            }
+        },
+    },
     /* Note when send the command to set sensitivity, press button on the device to make it wakeup*/
     DJT11LM_vibration_sensitivity: {
         key: 'sensitivity',

--- a/devices.js
+++ b/devices.js
@@ -9,28 +9,28 @@ const generic = {
         return {
             supports: 'on/off, brightness',
             fromZigbee: [fz.light_brightness, fz.light_state],
-            toZigbee: [tz.on_off, tz.light_brightness, tz.ignore_transition],
+            toZigbee: [tz.on_off, tz.light_brightness, tz.ignore_transition, tz.light_alert],
         };
     },
     light_onoff_brightness_colortemp: () => {
         return {
             supports: 'on/off, brightness, color temperature',
             fromZigbee: [fz.light_brightness, fz.light_color_colortemp, fz.light_state],
-            toZigbee: [tz.on_off, tz.light_brightness, tz.light_colortemp, tz.ignore_transition],
+            toZigbee: [tz.on_off, tz.light_brightness, tz.light_colortemp, tz.ignore_transition, tz.light_alert],
         };
     },
     light_onoff_brightness_colorxy: () => {
         return {
             supports: 'on/off, brightness, color xy',
             fromZigbee: [fz.light_brightness, fz.light_color_colortemp, fz.light_state],
-            toZigbee: [tz.on_off, tz.light_brightness, tz.light_color, tz.ignore_transition],
+            toZigbee: [tz.on_off, tz.light_brightness, tz.light_color, tz.ignore_transition, tz.light_alert],
         };
     },
     light_onoff_brightness_colortemp_colorxy: () => {
         return {
             supports: 'on/off, brightness, color temperature, color xy',
             fromZigbee: [fz.light_brightness, fz.light_color_colortemp, fz.light_state],
-            toZigbee: [tz.on_off, tz.light_brightness, tz.light_colortemp, tz.light_color, tz.ignore_transition],
+            toZigbee: [tz.on_off, tz.light_brightness, tz.light_colortemp, tz.light_color, tz.ignore_transition, tz.light_alert],
         };
     },
 };

--- a/devices.js
+++ b/devices.js
@@ -32,7 +32,7 @@ const generic = {
             fromZigbee: [fz.light_brightness, fz.light_color_colortemp, fz.light_state],
             toZigbee: [
                 tz.on_off, tz.light_brightness, tz.light_colortemp, tz.light_color, tz.ignore_transition,
-                tz.light_alert
+                tz.light_alert,
             ],
         };
     },

--- a/devices.js
+++ b/devices.js
@@ -30,7 +30,10 @@ const generic = {
         return {
             supports: 'on/off, brightness, color temperature, color xy',
             fromZigbee: [fz.light_brightness, fz.light_color_colortemp, fz.light_state],
-            toZigbee: [tz.on_off, tz.light_brightness, tz.light_colortemp, tz.light_color, tz.ignore_transition, tz.light_alert],
+            toZigbee: [
+                tz.on_off, tz.light_brightness, tz.light_colortemp, tz.light_color, tz.ignore_transition,
+                tz.light_alert
+            ],
         };
     },
 };


### PR DESCRIPTION
The feature used is not specific to Philips Hue, but your milage may vary. Tested on Philips Hue White and color ambiance and on Ikea Tradfri White.

Publish the following commands to your lightbulb thru mqtt:
{"alert":"select"} for a single blink
{"alert":"lselect"} for a longer blink time (I get 15 blinks in 15 seconds on Philips Hue)
{"alert":"none"} stop blinking 

The bulb will flash in the color you have set.
If the bulb is off you should first turn it on and set the desired color.