### PR TITLE
Remove tamper from heiman_smoke

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -679,7 +679,6 @@ const converters = {
             const zoneStatus = msg.data.zoneStatus;
             return {
                 smoke: (zoneStatus & 1) > 0, // Bit 1 = Alarm: Smoke
-                tamper: (zoneStatus & 1<<2) > 0, // Bit 3 = Tamper status
                 battery_low: (zoneStatus & 1<<4) > 0, // Bit 4 = Battery LOW indicator
             };
         },


### PR DESCRIPTION
Due to the HS3SA not having a tamper-switch, we can remove this status from the converter.
@arteck could you please confirm that for the other Heiman smoke detector? Please wait for his confirmation before merging. Thanks

@merlinschumacher