### PR TITLE
Add support for Xiaomi Aqara Curtain Motor (ZNCLDJ11LM)

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -704,12 +704,12 @@ const converters = {
         convert: (model, msg, publish, options) => {
             let running = false;
 
-            let runningData = msg.data.data['61440'];
+            const runningData = msg.data.data['61440'];
             if (runningData) {
                 running = runningData.toString().startsWith('117440') || runningData.toString().startsWith('591');
             }
 
-            let position = precisionRound(msg.data.data['presentValue'], 2);
+            const position = precisionRound(msg.data.data['presentValue'], 2);
 
             return {position: position, running: running};
         },

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -700,17 +700,29 @@ const converters = {
     },
     ZNCLDJ11LM_curtain_genAnalogOutput_change: {
         cid: 'genAnalogOutput',
+        type: 'devChange',
+        convert: (model, msg, publish, options) => {
+            let running = false;
+
+            if (msg.data.data['61440']) {
+                running = msg.data.data['61440'] !== 0;
+            }
+
+            const position = precisionRound(msg.data.data['presentValue'], 2);
+            return {position: position, running: running};
+        },
+    },
+    ZNCLDJ11LM_curtain_genAnalogOutput_report: {
+        cid: 'genAnalogOutput',
         type: 'attReport',
         convert: (model, msg, publish, options) => {
             let running = false;
 
-            const runningData = msg.data.data['61440'];
-            if (runningData) {
-                running = runningData.toString().startsWith('117440') || runningData.toString().startsWith('591');
+            if (msg.data.data['61440']) {
+                running = msg.data.data['61440'] !== 0;
             }
 
             const position = precisionRound(msg.data.data['presentValue'], 2);
-
             return {position: position, running: running};
         },
     },
@@ -1181,11 +1193,6 @@ const converters = {
     },
     ignore_analog_change: {
         cid: 'genAnalogInput',
-        type: 'devChange',
-        convert: (model, msg, publish, options) => null,
-    },
-    ignore_analogOutput_change: {
-        cid: 'genAnalogOutput',
         type: 'devChange',
         convert: (model, msg, publish, options) => null,
     },

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -703,37 +703,15 @@ const converters = {
         type: 'attReport',
         convert: (model, msg, publish, options) => {
             let running = false;
-            if (msg.data.data['61440']) {
-                if ((msg.data.data['61440'].toString()).startsWith('117440')
-            ||(msg.data.data['61440'].toString()).startsWith('591')) {
-                    running = true;
-                } else if (msg.data.data['61440']===0) {
-                    running = false;
-                }
 
-                return {presentValue: precisionRound(msg.data.data['presentValue'], 2), running: running};
+            let runningData = msg.data.data['61440'];
+            if (runningData) {
+                running = runningData.toString().startsWith('117440') || runningData.toString().startsWith('591');
             }
-            return {presentValue: precisionRound(msg.data.data['presentValue'], 2),
-                running: running};
-        },
-    },
-    ZNCLDJ11LM_curtain_closuresWindowCovering_change: {
-        cid: 'closuresWindowCovering',
-        type: 'attReport',
-        convert: (model, msg, publish, options) => {
-            if (msg.data.data['currentPositionLiftPercentage']) {
-                const lift = precisionRound(msg.data.data['currentPositionLiftPercentage'], 2);
-                return {currentPositionLiftPercentage: lift};
-            }
-        },
-    },
-    ZNCLDJ11LM_genBasic_change: {
-        cid: 'genBasic',
-        type: 'attReport',
-        convert: (model, msg, publish, options) => {
-            if (msg.data.data['65281']) {
-                return {summaryReport: msg.data.data['65281']};
-            }
+
+            let position = precisionRound(msg.data.data['presentValue'], 2);
+
+            return {position: position, running: running};
         },
     },
     JTYJGD01LMBW_smoke: {
@@ -1248,6 +1226,16 @@ const converters = {
     },
     ignore_light_color_colortemp_report: {
         cid: 'lightingColorCtrl',
+        type: 'attReport',
+        convert: (model, msg, publish, options) => null,
+    },
+    ignore_closuresWindowCovering_change: {
+        cid: 'closuresWindowCovering',
+        type: 'devChange',
+        convert: (model, msg, publish, options) => null,
+    },
+    ignore_closuresWindowCovering_report: {
+        cid: 'closuresWindowCovering',
         type: 'attReport',
         convert: (model, msg, publish, options) => null,
     },

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -698,6 +698,44 @@ const converters = {
             }
         },
     },
+    ZNCLDJ11LM_curtain_genAnalogOutput_change: {
+        cid: 'genAnalogOutput',
+        type: 'attReport',
+        convert: (model, msg, publish, options) => {
+            let running = false;
+            if (msg.data.data['61440']) {
+                if ((msg.data.data['61440'].toString()).startsWith('117440')
+            ||(msg.data.data['61440'].toString()).startsWith('591')) {
+                    running = true;
+                } else if (msg.data.data['61440']===0) {
+                    running = false;
+                }
+
+                return {presentValue: precisionRound(msg.data.data['presentValue'], 2), running: running};
+            }
+            return {presentValue: precisionRound(msg.data.data['presentValue'], 2),
+                running: running};
+        },
+    },
+    ZNCLDJ11LM_curtain_closuresWindowCovering_change: {
+        cid: 'closuresWindowCovering',
+        type: 'attReport',
+        convert: (model, msg, publish, options) => {
+            if (msg.data.data['currentPositionLiftPercentage']) {
+                const lift = precisionRound(msg.data.data['currentPositionLiftPercentage'], 2);
+                return {currentPositionLiftPercentage: lift};
+            }
+        },
+    },
+    ZNCLDJ11LM_genBasic_change: {
+        cid: 'genBasic',
+        type: 'attReport',
+        convert: (model, msg, publish, options) => {
+            if (msg.data.data['65281']) {
+                return {summaryReport: msg.data.data['65281']};
+            }
+        },
+    },
     JTYJGD01LMBW_smoke: {
         cid: 'ssIasZone',
         type: 'statusChange',
@@ -1165,6 +1203,11 @@ const converters = {
     },
     ignore_analog_change: {
         cid: 'genAnalogInput',
+        type: 'devChange',
+        convert: (model, msg, publish, options) => null,
+    },
+    ignore_analogOutput_change: {
+        cid: 'genAnalogOutput',
         type: 'devChange',
         convert: (model, msg, publish, options) => null,
     },

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -308,6 +308,46 @@ const converters = {
             }
         },
     },
+    ZNCLDJ11LM_control: {
+        key: 'state',
+        convert: (key, value, message, type) => {
+            const lookup = {
+                'open': 'upOpen',
+                'close': 'downClose',
+                'stop': 'stop',
+                'on': 'upOpen',
+                'off': 'downClose',
+            };
+
+            if (lookup[value]) {
+                value = lookup[value];
+            }
+
+            return {
+                cid: 'closuresWindowCovering',
+                cmd: value,
+                cmdType: 'functional',
+                zclData: {},
+                cfg: cfg.default,
+            };
+        },
+    },
+    ZNCLDJ11LM_control_percentage: {
+        key: 'percentage',
+        convert: (key, value, message, type) => {
+            return {
+                cid: 'genAnalogOutput',
+                cmd: 'write',
+                cmdType: 'foundation',
+                zclData: [{
+                    attrId: 0x0055,
+                    dataType: 0x39,
+                    attrData: value,
+                }],
+                cfg: cfg.default,
+            };
+        },
+    },
 
     // Ignore converters
     ignore_transition: {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -320,7 +320,7 @@ const converters = {
             };
 
             value = value.toLowerCase();
-            if (lookup[value]) {  
+            if (lookup[value]) {
                 return {
                     cid: 'closuresWindowCovering',
                     cmd: lookup[value],

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -320,17 +320,15 @@ const converters = {
             };
             
             value = value.toLowerCase();
-            if (lookup[value]) {
-                value = lookup[value];
+            if (lookup[value]) {               
+                return {
+                    cid: 'closuresWindowCovering',
+                    cmd: lookup[value],
+                    cmdType: 'functional',
+                    zclData: {},
+                    cfg: cfg.default,
+                };
             }
-
-            return {
-                cid: 'closuresWindowCovering',
-                cmd: value,
-                cmdType: 'functional',
-                zclData: {},
-                cfg: cfg.default,
-            };
         },
     },
     ZNCLDJ11LM_control_position: {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -332,8 +332,8 @@ const converters = {
             };
         },
     },
-    ZNCLDJ11LM_control_percentage: {
-        key: 'percentage',
+    ZNCLDJ11LM_control_position: {
+        key: 'position',
         convert: (key, value, message, type) => {
             return {
                 cid: 'genAnalogOutput',

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -318,9 +318,9 @@ const converters = {
                 'on': 'upOpen',
                 'off': 'downClose',
             };
-            
+
             value = value.toLowerCase();
-            if (lookup[value]) {               
+            if (lookup[value]) {  
                 return {
                     cid: 'closuresWindowCovering',
                     cmd: lookup[value],

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -318,7 +318,8 @@ const converters = {
                 'on': 'upOpen',
                 'off': 'downClose',
             };
-
+            
+            value = value.toLowerCase();
             if (lookup[value]) {
                 value = lookup[value];
             }

--- a/devices.js
+++ b/devices.js
@@ -360,7 +360,7 @@ const devices = [
         supports: 'open, close, stop, position',
         vendor: 'Xiaomi',
         fromZigbee: [
-            fz.ZNCLDJ11LM_curtain_genAnalogOutput_change, 
+            fz.ZNCLDJ11LM_curtain_genAnalogOutput_change,
             fz.ignore_closuresWindowCovering_change, fz.ignore_closuresWindowCovering_report,
             fz.ignore_basic_report, fz.ignore_basic_change, fz.ignore_analogOutput_change,
         ],

--- a/devices.js
+++ b/devices.js
@@ -360,9 +360,9 @@ const devices = [
         supports: 'open, close, stop, position',
         vendor: 'Xiaomi',
         fromZigbee: [
-            fz.ZNCLDJ11LM_curtain_genAnalogOutput_change,
+            fz.ZNCLDJ11LM_curtain_genAnalogOutput_change, fz.ZNCLDJ11LM_curtain_genAnalogOutput_report,
             fz.ignore_closuresWindowCovering_change, fz.ignore_closuresWindowCovering_report,
-            fz.ignore_basic_report, fz.ignore_basic_change, fz.ignore_analogOutput_change,
+            fz.ignore_basic_change, fz.ignore_basic_report,
         ],
         toZigbee: [tz.ZNCLDJ11LM_control, tz.ZNCLDJ11LM_control_position],
     },

--- a/devices.js
+++ b/devices.js
@@ -357,13 +357,14 @@ const devices = [
         zigbeeModel: ['lumi.curtain'],
         model: 'ZNCLDJ11LM',
         description: 'Aqara curtain motor',
-        supports: 'open, close, stop, percentage',
+        supports: 'open, close, stop, position',
         vendor: 'Xiaomi',
         fromZigbee: [
-            fz.ZNCLDJ11LM_curtain_closuresWindowCovering_change, fz.ZNCLDJ11LM_curtain_genAnalogOutput_change,
-            fz.ZNCLDJ11LM_genBasic_change, fz.ignore_basic_change, fz.ignore_analogOutput_change,
+            fz.ZNCLDJ11LM_curtain_genAnalogOutput_change, 
+            fz.ignore_closuresWindowCovering_change, fz.ignore_closuresWindowCovering_report,
+            fz.ignore_basic_report, fz.ignore_basic_change, fz.ignore_analogOutput_change,
         ],
-        toZigbee: [tz.ZNCLDJ11LM_control, tz.ZNCLDJ11LM_control_percentage],
+        toZigbee: [tz.ZNCLDJ11LM_control, tz.ZNCLDJ11LM_control_position],
     },
 
     // IKEA

--- a/devices.js
+++ b/devices.js
@@ -356,7 +356,7 @@ const devices = [
     {
         zigbeeModel: ['lumi.curtain'],
         model: 'ZNCLDJ11LM',
-        description: 'Aqara curtain motor',
+        description: 'Aqara smart curtain',
         supports: 'open, close, stop, position',
         vendor: 'Xiaomi',
         fromZigbee: [

--- a/devices.js
+++ b/devices.js
@@ -353,6 +353,18 @@ const devices = [
         ],
         toZigbee: [tz.DJT11LM_vibration_sensitivity],
     },
+    {
+        zigbeeModel: ['lumi.curtain'],
+        model: 'ZNCLDJ11LM',
+        description: 'Aqara curtain motor',
+        supports: 'open, close, stop, percentage',
+        vendor: 'Xiaomi',
+        fromZigbee: [
+            fz.ZNCLDJ11LM_curtain_closuresWindowCovering_change, fz.ZNCLDJ11LM_curtain_genAnalogOutput_change,
+            fz.ZNCLDJ11LM_genBasic_change, fz.ignore_basic_change, fz.ignore_analogOutput_change,
+        ],
+        toZigbee: [tz.ZNCLDJ11LM_control, tz.ZNCLDJ11LM_control_percentage],
+    },
 
     // IKEA
     {

--- a/devices.js
+++ b/devices.js
@@ -356,7 +356,7 @@ const devices = [
     {
         zigbeeModel: ['lumi.curtain'],
         model: 'ZNCLDJ11LM',
-        description: 'Aqara smart curtain',
+        description: 'Aqara curtain motor',
         supports: 'open, close, stop, position',
         vendor: 'Xiaomi',
         fromZigbee: [


### PR DESCRIPTION
This code is based on @dzungpv pull request but was adapted to work with the latest master.
Mainly the toZigbee.js needed adjustments (cmdType instead of type, removal of attr field, zclData in array, etc.)

The following MQTT topics work:

- /set {"state":"open"} // Opens curtain fully
- /set {"state":"close"} // Closes curtain fully
- /set {"state":"stop"} // Stops movement of curtain
- /set {"position":"X"} // Opens curtain to X percent (X between 0 and 100)

The reported "position" describes the current opening of the curtain.

Everything was tested with a real device.