### PR TITLE
Got new deice working GLEDOPTO GL-B-008Z

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -732,6 +732,26 @@ const devices = [
         fromZigbee: generic.light_onoff_brightness_colortemp_colorxy().fromZigbee,
         toZigbee: generic.light_onoff_brightness_colortemp_colorxy().toZigbee,
     },
+
+    // TODO
+    {
+        zigbeeModel: ['FB56+ZSC05HG1.0'],
+        model: 'TODO',
+        vendor: 'TODO',
+        description: 'TODO',
+        supports: 'TODO',
+        fromZigbee: [],
+        toZigbee: [],
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const device = shepherd.find(ieeeAddr, 11);
+
+            if (device) {
+                device.report('genOnOff', 'onOff', 0, 1000, 1, (error) => {
+                    callback(!error);
+                });
+            }
+        },
+    },
 ];
 
 module.exports = devices;

--- a/devices.js
+++ b/devices.js
@@ -743,11 +743,20 @@ const devices = [
         fromZigbee: [],
         toZigbee: [],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
-            const device = shepherd.find(ieeeAddr, 11);
+            const cfgRptRec = {
+                direction: 0, attrId: 0, dataType: 16, minRepIntval: 0, maxRepIntval: 1000, repChange: 0,
+            };
 
+            const device = shepherd.find(ieeeAddr, 11);
             if (device) {
-                device.report('genOnOff', 'onOff', 0, 1000, 1, (error) => {
-                    callback(!error);
+                device.bind('genOnOff', coordinator, (error) => {
+                    if (error) {
+                        callback(error);
+                    } else {
+                        device.foundation('genOnOff', 'configReport', [cfgRptRec]).then((rsp) => {
+                            callback(rsp[0].status === 0);
+                        });
+                    }
                 });
             }
         },


### PR DESCRIPTION
Just got the new E27 RGB Bulb GL-B-008Z from GLEDOPTO working with Home Assistant. May you please add this to the new version:

homeassistant.js
	'GL-B-008Z': [configurations.light_brightness_colortemp_xy],
	
devices.js
    // Gledopto
    {
        zigbeeModel: ['GL-B-008Z'],
        model: 'GL-B-008Z',
        vendor: 'GLEDOPTO',
        description: 'LED RGB E27 Bulb',
        supports: generic.light_onoff_brightness_colortemp_colorxy().supports,
        fromZigbee: generic.light_onoff_brightness_colortemp_colorxy().fromZigbee,
        toZigbee: generic.light_onoff_brightness_colortemp_colorxy().toZigbee,
		ep: (device) => {
            if (device.epList.toString() === '11,12,13') {
                return {'': 12};
            } else if (device.epList.toString() === '10,11,13' || device.epList.toString() === '11,13') {
                return {'': 11};
            } else {
                return {};
            }
        },
    },