### PR TITLE
Support setting color by hex value

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -136,6 +136,10 @@ const converters = {
                     const xy = utils.rgbToXY(rgb[0], rgb[1], rgb[2]);
                     value.x = xy.x;
                     value.y = xy.y;
+                } else if (value.hasOwnProperty('hex')) {
+                    const xy = utils.hexToXY(value.hex);
+                    value.x = xy.x;
+                    value.y = xy.y;
                 }
 
                 return {

--- a/converters/utils.js
+++ b/converters/utils.js
@@ -40,6 +40,7 @@ function hexToXY(hex) {
 }
 
 function hexToRgb(hex) {
+    hex = hex.replace('#', '');
     const bigint = parseInt(hex, 16);
     const r = (bigint >> 16) & 255;
     const g = (bigint >> 8) & 255;

--- a/converters/utils.js
+++ b/converters/utils.js
@@ -34,6 +34,22 @@ function rgbToXY(red, green, blue) {
     return {x: Number.parseFloat(x), y: Number.parseFloat(y)};
 }
 
+function hexToXY(hex) {
+    const rgb = hexToRgb(hex);
+    return rgbToXY(rgb.r, rgb.g, rgb.b);
+}
+
+function hexToRgb(hex) {
+    const bigint = parseInt(hex, 16);
+    const r = (bigint >> 16) & 255;
+    const g = (bigint >> 8) & 255;
+    const b = bigint & 255;
+
+    return {r: r, g: g, b: b};
+}
+
 module.exports = {
     rgbToXY: rgbToXY,
+    hexToXY: hexToXY,
+    hexToRgb: hexToRgb,
 };


### PR DESCRIPTION
Setting color is also possible with hex values. 

/set {"color":{"hex":"547CFF"}}

This simplifies FHEM integration a lot as FHEM color pickers work in hex  