### PR TITLE
Add support for round Hue Aurelle LTC016

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -682,6 +682,15 @@ const devices = [
         toZigbee: generic.light_onoff_brightness_colortemp.toZigbee,
     },
     {
+        zigbeeModel: ['LTC016'],
+        model: '3216431P5',
+        vendor: 'Philips',
+        description: 'Philips Hue White ambiance Aurelle Round Panel Light',
+        supports: generic.light_onoff_brightness_colortemp().supports,
+        fromZigbee: generic.light_onoff_brightness_colortemp().fromZigbee,
+        toZigbee: generic.light_onoff_brightness_colortemp().toZigbee,
+    },
+    {
         zigbeeModel: ['LLC010'],
         model: '7199960PH',
         vendor: 'Philips',


### PR DESCRIPTION
Tested with two devices for a while. Works as expected.