### PR TITLE
Add support for Sengled E12-N14 (BR30) Light

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1449,6 +1449,15 @@ const devices = [
         fromZigbee: generic.light_onoff_brightness_colortemp_colorxy.fromZigbee,
         toZigbee: generic.light_onoff_brightness_colortemp_colorxy.toZigbee,
     },
+    {
+        zigbeeModel: ['E12-N14'],
+        model: 'E12-N14',
+        vendor: 'Sengled',
+        description: 'Element Classic (BR30)',
+        supports: generic.light_onoff_brightness.supports,
+        fromZigbee: generic.light_onoff_brightness.fromZigbee,
+        toZigbee: generic.light_onoff_brightness.toZigbee,
+    },
 
     // JIAWEN
     {


### PR DESCRIPTION
Added support for Element Classic BR30 Soft White 2700K (E12-N14) from [Sengled](https://us.sengled.com/products/element-classic-bulb-br30).