### PR TITLE
Bitron-Video Wall Thermostat

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -174,26 +174,12 @@ const converters = {
         cid: 'hvacThermostat',
         type: 'attReport',
         convert: (model, msg, publish, options) => {
-            const deviceID = msg.endpoints[0].device.ieeeAddr;
-            if (!store[deviceID]) {
-                store[deviceID] = {localTemp: null};
-                store[deviceID] = {occupiedHeatingSetpoint: null};
-                store[deviceID] = {runningState: null};
-            }
-            if (typeof msg.data.data.localTemp == 'number') {
-                store[deviceID].localTemp = msg.data.data.localTemp;
-            }
-            if ( typeof msg.data.data.occupiedHeatingSetpoint == 'number') {
-                store[deviceID].occupiedHeatingSetpoint = msg.data.data.occupiedHeatingSetpoint;
-            }
-            if (typeof msg.data.data.runningState == 'number') {
-                store[deviceID].runningState = msg.data.data.runningState;
-            }
             return {
-                localTemp: precisionRound(store[deviceID].localTemp, 2)/100,
-                occupiedHeatingSetpoint: precisionRound(store[deviceID].occupiedHeatingSetpoint, 2)/100,
-                runningState: store[deviceID].runningState === 1 ? 'ON' : 'OFF',
-                batteryAlarmState: msg.data.data.batteryAlarmState === 1 ? 'ON' : 'OFF',
+                local_temperature: precisionRound(msg.data.data['localTemp'], 2) / 100,
+                local_temperature_calibration: precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10,
+                occupied_heating_setpoint: precisionRound(msg.data.data['occupiedHeatingSetpoint'], 2) / 100,
+                running_state: msg.data.data['runningState'] === 1 ? 'ON' : 'OFF',
+                battery_alarm_state: msg.data.data['batteryAlarmState'] === 1 ? 'ON' : 'OFF',
             };
         },
     },
@@ -201,26 +187,12 @@ const converters = {
         cid: 'hvacThermostat',
         type: 'devChange',
         convert: (model, msg, publish, options) => {
-            const deviceID = msg.endpoints[0].device.ieeeAddr;
-            if (!store[deviceID]) {
-                store[deviceID] = {localTemp: null};
-                store[deviceID] = {occupiedHeatingSetpoint: null};
-                store[deviceID] = {runningState: null};
-            }
-            if (typeof msg.data.data.localTemp == 'number') {
-                store[deviceID].localTemp = msg.data.data.localTemp;
-            }
-            if (typeof msg.data.data.occupiedHeatingSetpoint == 'number') {
-                store[deviceID].occupiedHeatingSetpoint = msg.data.data.occupiedHeatingSetpoint;
-            }
-            if (typeof msg.data.data.runningState == 'number') {
-                store[deviceID].runningState = msg.data.data.runningState;
-            }
             return {
-                localTemp: precisionRound(store[deviceID].localTemp, 2)/100,
-                occupiedHeatingSetpoint: precisionRound(store[deviceID].occupiedHeatingSetpoint, 2)/100,
-                runningState: store[deviceID].runningState === 1 ? 'ON' : 'OFF',
-                batteryAlarmState: msg.data.data.batteryAlarmState === 1 ? 'ON' : 'OFF',
+                local_temperature: precisionRound(msg.data.data['localTemp'], 2) / 100,
+                local_temperature_calibration: precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10,
+                occupied_heating_setpoint: precisionRound(msg.data.data['occupiedHeatingSetpoint'], 2) / 100,
+                running_state: msg.data.data['runningState'] === 1 ? 'ON' : 'OFF',
+                battery_alarm_state: msg.data.data['batteryAlarmState'] === 1 ? 'ON' : 'OFF',
             };
         },
     },

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -174,42 +174,58 @@ const converters = {
         cid: 'hvacThermostat',
         type: 'attReport',
         convert: (model, msg, publish, options) => {
+            const result = {};
+
             if (typeof msg.data.data['localTemp'] == 'number') {
-                return {local_temperature: precisionRound(msg.data.data['localTemp'], 2) / 100}; 
+                result.local_temperature = precisionRound(msg.data.data['localTemp'], 2) / 100; 
             }
+
             if (typeof msg.data.data['localTemperatureCalibration'] == 'number') {
-                return {local_temperature_calibration: precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10};
+                result.local_temperature_calibration = precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10;
             }
+
             if (typeof msg.data.data['occupiedHeatingSetpoint'] == 'number') {
-                return {occupied_heating_setpoint: precisionRound(msg.data.data['occupiedHeatingSetpoint'], 2) / 100};
+                result.occupied_heating_setpoint = precisionRound(msg.data.data['occupiedHeatingSetpoint'], 2) / 100;
             }
+
             if (typeof msg.data.data['runningState'] == 'number') {
-                return {running_state: msg.data.data['runningState']};
-            }            
+                result.running_state = msg.data.data['runningState'];
+            } 
+
             if (typeof msg.data.data['batteryAlarmState'] == 'number') {
-                return {battery_alarm_state: msg.data.data['batteryAlarmState']};           
+                result.battery_alarm_state = msg.data.data['batteryAlarmState'];           
             }
+
+            return result;
         },
     },
     bitron_thermostat_dev_change: {
         cid: 'hvacThermostat',
         type: 'devChange',
         convert: (model, msg, publish, options) => {
+            const result = {};
+
             if (typeof msg.data.data['localTemp'] == 'number') {
-                return {local_temperature: precisionRound(msg.data.data['localTemp'], 2) / 100}; 
+                result.local_temperature = precisionRound(msg.data.data['localTemp'], 2) / 100; 
             }
+
             if (typeof msg.data.data['localTemperatureCalibration'] == 'number') {
-                return {local_temperature_calibration: precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10};
+                result.local_temperature_calibration = precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10;
             }
+
             if (typeof msg.data.data['occupiedHeatingSetpoint'] == 'number') {
-                return {occupied_heating_setpoint: precisionRound(msg.data.data['occupiedHeatingSetpoint'], 2) / 100};
+                result.occupied_heating_setpoint = precisionRound(msg.data.data['occupiedHeatingSetpoint'], 2) / 100;
             }
+
             if (typeof msg.data.data['runningState'] == 'number') {
-                return {running_state: msg.data.data['runningState']};
-            }            
+                result.running_state = msg.data.data['runningState'];
+            } 
+
             if (typeof msg.data.data['batteryAlarmState'] == 'number') {
-                return {battery_alarm_state: msg.data.data['batteryAlarmState']};           
+                result.battery_alarm_state = msg.data.data['batteryAlarmState'];           
             }
+            
+            return result;
         },
     },
     smartthings_contact: {

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -174,26 +174,42 @@ const converters = {
         cid: 'hvacThermostat',
         type: 'attReport',
         convert: (model, msg, publish, options) => {
-            return {
-                local_temperature: precisionRound(msg.data.data['localTemp'], 2) / 100,
-                local_temperature_calibration: precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10,
-                occupied_heating_setpoint: precisionRound(msg.data.data['occupiedHeatingSetpoint'], 2) / 100,
-                running_state: msg.data.data['runningState'] === 1 ? 'ON' : 'OFF',
-                battery_alarm_state: msg.data.data['batteryAlarmState'] === 1 ? 'ON' : 'OFF',
-            };
+            if (typeof msg.data.data['localTemp'] == 'number') {
+                return {local_temperature: precisionRound(msg.data.data['localTemp'], 2) / 100}; 
+            }
+            if (typeof msg.data.data['localTemperatureCalibration'] == 'number') {
+                return {local_temperature_calibration: precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10};
+            }
+            if (typeof msg.data.data['occupiedHeatingSetpoint'] == 'number') {
+                return {occupied_heating_setpoint: precisionRound(msg.data.data['occupiedHeatingSetpoint'], 2) / 100};
+            }
+            if (typeof msg.data.data['runningState'] == 'number') {
+                return {running_state: msg.data.data['runningState']};
+            }            
+            if (typeof msg.data.data['batteryAlarmState'] == 'number') {
+                return {battery_alarm_state: msg.data.data['batteryAlarmState']};           
+            }
         },
     },
     bitron_thermostat_dev_change: {
         cid: 'hvacThermostat',
         type: 'devChange',
         convert: (model, msg, publish, options) => {
-            return {
-                local_temperature: precisionRound(msg.data.data['localTemp'], 2) / 100,
-                local_temperature_calibration: precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10,
-                occupied_heating_setpoint: precisionRound(msg.data.data['occupiedHeatingSetpoint'], 2) / 100,
-                running_state: msg.data.data['runningState'] === 1 ? 'ON' : 'OFF',
-                battery_alarm_state: msg.data.data['batteryAlarmState'] === 1 ? 'ON' : 'OFF',
-            };
+            if (typeof msg.data.data['localTemp'] == 'number') {
+                return {local_temperature: precisionRound(msg.data.data['localTemp'], 2) / 100}; 
+            }
+            if (typeof msg.data.data['localTemperatureCalibration'] == 'number') {
+                return {local_temperature_calibration: precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10};
+            }
+            if (typeof msg.data.data['occupiedHeatingSetpoint'] == 'number') {
+                return {occupied_heating_setpoint: precisionRound(msg.data.data['occupiedHeatingSetpoint'], 2) / 100};
+            }
+            if (typeof msg.data.data['runningState'] == 'number') {
+                return {running_state: msg.data.data['runningState']};
+            }            
+            if (typeof msg.data.data['batteryAlarmState'] == 'number') {
+                return {battery_alarm_state: msg.data.data['batteryAlarmState']};           
+            }
         },
     },
     smartthings_contact: {

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -176,7 +176,7 @@ const converters = {
         convert: (model, msg, publish, options) => {
             const result = {};
             if (typeof msg.data.data['localTemp'] == 'number') {
-                result.local_temperature = precisionRound(msg.data.data['localTemp'], 2) / 100; 
+                result.local_temperature = precisionRound(msg.data.data['localTemp'], 2) / 100;
             }
             if (typeof msg.data.data['localTemperatureCalibration'] == 'number') {
                 result.local_temperature_calibration = precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10;
@@ -186,9 +186,9 @@ const converters = {
             }
             if (typeof msg.data.data['runningState'] == 'number') {
                 result.running_state = msg.data.data['runningState'];
-            } 
+            }
             if (typeof msg.data.data['batteryAlarmState'] == 'number') {
-                result.battery_alarm_state = msg.data.data['batteryAlarmState'];           
+                result.battery_alarm_state = msg.data.data['batteryAlarmState'];
             }
             return result;
         },
@@ -199,7 +199,7 @@ const converters = {
         convert: (model, msg, publish, options) => {
             const result = {};
             if (typeof msg.data.data['localTemp'] == 'number') {
-                result.local_temperature = precisionRound(msg.data.data['localTemp'], 2) / 100; 
+                result.local_temperature = precisionRound(msg.data.data['localTemp'], 2) / 100;
             }
             if (typeof msg.data.data['localTemperatureCalibration'] == 'number') {
                 result.local_temperature_calibration = precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10;
@@ -209,10 +209,10 @@ const converters = {
             }
             if (typeof msg.data.data['runningState'] == 'number') {
                 result.running_state = msg.data.data['runningState'];
-            } 
+            }
             if (typeof msg.data.data['batteryAlarmState'] == 'number') {
-                result.battery_alarm_state = msg.data.data['batteryAlarmState'];           
-            }         
+                result.battery_alarm_state = msg.data.data['batteryAlarmState'];
+            }
             return result;
         },
     },

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -179,10 +179,12 @@ const converters = {
                 result.local_temperature = precisionRound(msg.data.data['localTemp'], 2) / 100;
             }
             if (typeof msg.data.data['localTemperatureCalibration'] == 'number') {
-                result.local_temperature_calibration = precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10;
+                result.local_temperature_calibration =
+                    precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10;
             }
             if (typeof msg.data.data['occupiedHeatingSetpoint'] == 'number') {
-                result.occupied_heating_setpoint = precisionRound(msg.data.data['occupiedHeatingSetpoint'], 2) / 100;
+                result.occupied_heating_setpoint =
+                    precisionRound(msg.data.data['occupiedHeatingSetpoint'], 2) / 100;
             }
             if (typeof msg.data.data['runningState'] == 'number') {
                 result.running_state = msg.data.data['runningState'];
@@ -202,10 +204,12 @@ const converters = {
                 result.local_temperature = precisionRound(msg.data.data['localTemp'], 2) / 100;
             }
             if (typeof msg.data.data['localTemperatureCalibration'] == 'number') {
-                result.local_temperature_calibration = precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10;
+                result.local_temperature_calibration =
+                    precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10;
             }
             if (typeof msg.data.data['occupiedHeatingSetpoint'] == 'number') {
-                result.occupied_heating_setpoint = precisionRound(msg.data.data['occupiedHeatingSetpoint'], 2) / 100;
+                result.occupied_heating_setpoint =
+                    precisionRound(msg.data.data['occupiedHeatingSetpoint'], 2) / 100;
             }
             if (typeof msg.data.data['runningState'] == 'number') {
                 result.running_state = msg.data.data['runningState'];

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -158,6 +158,72 @@ const converters = {
             return {occupancy: true};
         },
     },
+    bitron_battery: {
+        cid: 'genPowerCfg',
+        type: 'attReport',
+        convert: (model, msg, publish, options) => {
+            const battery = {max: 3200, min: 2500};
+            const voltage = msg.data.data['batteryVoltage'] * 100;
+            return {
+                battery: toPercentage(voltage, battery.min, battery.max),
+                voltage: voltage,
+            };
+        },
+    },
+    bitron_thermostat_att_report: {
+        cid: 'hvacThermostat',
+        type: 'attReport',
+        convert: (model, msg, publish, options) => {
+            const deviceID = msg.endpoints[0].device.ieeeAddr;
+            if (!store[deviceID]) {
+                store[deviceID] = {localTemp: null};
+                store[deviceID] = {occupiedHeatingSetpoint: null};
+                store[deviceID] = {runningState: null};
+            }
+            if (typeof msg.data.data.localTemp == 'number') {
+                store[deviceID].localTemp = msg.data.data.localTemp;
+            }
+            if ( typeof msg.data.data.occupiedHeatingSetpoint == 'number') {
+                store[deviceID].occupiedHeatingSetpoint = msg.data.data.occupiedHeatingSetpoint;
+            }
+            if (typeof msg.data.data.runningState == 'number') {
+                store[deviceID].runningState = msg.data.data.runningState;
+            }
+            return {
+                localTemp: precisionRound(store[deviceID].localTemp, 2)/100,
+                occupiedHeatingSetpoint: precisionRound(store[deviceID].occupiedHeatingSetpoint, 2)/100,
+                runningState: store[deviceID].runningState === 1 ? 'ON' : 'OFF',
+                batteryAlarmState: msg.data.data.batteryAlarmState === 1 ? 'ON' : 'OFF',
+            };
+        },
+    },
+    bitron_thermostat_dev_change: {
+        cid: 'hvacThermostat',
+        type: 'devChange',
+        convert: (model, msg, publish, options) => {
+            const deviceID = msg.endpoints[0].device.ieeeAddr;
+            if (!store[deviceID]) {
+                store[deviceID] = {localTemp: null};
+                store[deviceID] = {occupiedHeatingSetpoint: null};
+                store[deviceID] = {runningState: null};
+            }
+            if (typeof msg.data.data.localTemp == 'number') {
+                store[deviceID].localTemp = msg.data.data.localTemp;
+            }
+            if (typeof msg.data.data.occupiedHeatingSetpoint == 'number') {
+                store[deviceID].occupiedHeatingSetpoint = msg.data.data.occupiedHeatingSetpoint;
+            }
+            if (typeof msg.data.data.runningState == 'number') {
+                store[deviceID].runningState = msg.data.data.runningState;
+            }
+            return {
+                localTemp: precisionRound(store[deviceID].localTemp, 2)/100,
+                occupiedHeatingSetpoint: precisionRound(store[deviceID].occupiedHeatingSetpoint, 2)/100,
+                runningState: store[deviceID].runningState === 1 ? 'ON' : 'OFF',
+                batteryAlarmState: msg.data.data.batteryAlarmState === 1 ? 'ON' : 'OFF',
+            };
+        },
+    },
     smartthings_contact: {
         cid: 'ssIasZone',
         type: 'statusChange',

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -175,27 +175,21 @@ const converters = {
         type: 'attReport',
         convert: (model, msg, publish, options) => {
             const result = {};
-
             if (typeof msg.data.data['localTemp'] == 'number') {
                 result.local_temperature = precisionRound(msg.data.data['localTemp'], 2) / 100; 
             }
-
             if (typeof msg.data.data['localTemperatureCalibration'] == 'number') {
                 result.local_temperature_calibration = precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10;
             }
-
             if (typeof msg.data.data['occupiedHeatingSetpoint'] == 'number') {
                 result.occupied_heating_setpoint = precisionRound(msg.data.data['occupiedHeatingSetpoint'], 2) / 100;
             }
-
             if (typeof msg.data.data['runningState'] == 'number') {
                 result.running_state = msg.data.data['runningState'];
             } 
-
             if (typeof msg.data.data['batteryAlarmState'] == 'number') {
                 result.battery_alarm_state = msg.data.data['batteryAlarmState'];           
             }
-
             return result;
         },
     },
@@ -204,27 +198,21 @@ const converters = {
         type: 'devChange',
         convert: (model, msg, publish, options) => {
             const result = {};
-
             if (typeof msg.data.data['localTemp'] == 'number') {
                 result.local_temperature = precisionRound(msg.data.data['localTemp'], 2) / 100; 
             }
-
             if (typeof msg.data.data['localTemperatureCalibration'] == 'number') {
                 result.local_temperature_calibration = precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10;
             }
-
             if (typeof msg.data.data['occupiedHeatingSetpoint'] == 'number') {
                 result.occupied_heating_setpoint = precisionRound(msg.data.data['occupiedHeatingSetpoint'], 2) / 100;
             }
-
             if (typeof msg.data.data['runningState'] == 'number') {
                 result.running_state = msg.data.data['runningState'];
             } 
-
             if (typeof msg.data.data['batteryAlarmState'] == 'number') {
                 result.battery_alarm_state = msg.data.data['batteryAlarmState'];           
-            }
-            
+            }         
             return result;
         },
     },

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -305,7 +305,7 @@ const converters = {
                     zclData: [{
                         attrId: zclId.attr(cid, attrId).value,
                         dataType: zclId.attrType(cid, attrId).value,
-                        attrData: Math.round(value) * 100,
+                        attrData: (Math.round((value * 2).toFixed(1))/2).toFixed(1) * 100,
                     }],
                     cfg: cfg.default,
                 };
@@ -333,7 +333,7 @@ const converters = {
                     zclData: [{
                         attrId: zclId.attr(cid, attrId).value,
                         dataType: zclId.attrType(cid, attrId).value,
-                        attrData: Math.round(value) * 100, // TODO: Lookup in Zigbee documentation
+                        attrData: (Math.round((value * 2).toFixed(1))/2).toFixed(1) * 100,
                     }],
                     cfg: cfg.default,
                 };

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -573,6 +573,44 @@ const converters = {
             };
         },
     },
+    thermostat_running_state: {
+        key: 'running_state',
+        convert: (key, value, message, type) => {
+            const cid = 'hvacThermostat';
+            const attrId = 'runningState';
+            if (type === 'get') {
+                return {
+                    cid: cid,
+                    cmd: 'read',
+                    cmdType: 'foundation',
+                    zclData: [{attrId: zclId.attr(cid, attrId).value}],
+                    cfg: cfg.default,
+                };
+            }
+        },
+    },
+    thermostat_temperature_display_mode: {
+        key: 'temperature_display_mode',
+        convert: (key, value, message, type) => {
+            const cid = 'hvacUserInterfaceCfg';
+            const attrId = 'tempDisplayMode';
+            if (type === 'set') {
+                return {
+                    cid: cid,
+                    cmd: 'write',
+                    cmdType: 'foundation',
+                    zclData: [{
+                        // 0x00 Temperature in °C
+                        // 0x01 Temperature in °F
+                        attrId: zclId.attr(cid, attrId).value,
+                        dataType: zclId.attrType(cid, attrId).value,
+                        attrData: value,
+                    }],
+                    cfg: cfg.default,
+                };
+            }
+        },
+    },
     /*
      * Note when send the command to set sensitivity, press button on the device
      * to make it wakeup

--- a/devices.js
+++ b/devices.js
@@ -1613,6 +1613,7 @@ const devices = [
                 (cb) => device.bind('genPowerCfg', coordinator, cb),
                 (cb) => device.bind('hvacThermostat', coordinator, cb),
                 (cb) => device.report('hvacThermostat', 'localTemp', 300, 3600, 0, cb),
+                (cb) => device.report('hvacThermostat', 'local_temperature_calibration', 1, 0, 1, cb),
                 (cb) => device.report('hvacThermostat', 'runningState', 1, 0, 0, cb),
                 (cb) => device.report('hvacThermostat', 'occupiedHeatingSetpoint', 1, 0, 1, cb),
                 (cb) => device.report('genPowerCfg', 'batteryVoltage', 1800, 43200, 0, cb),

--- a/devices.js
+++ b/devices.js
@@ -1874,7 +1874,8 @@ const devices = [
         ],
         toZigbee: [
             tz.thermostat_occupied_heating_setpoint, tz.thermostat_local_temperature_calibration,
-            tz.thermostat_local_temperature,
+            tz.thermostat_local_temperature, tz.thermostat_running_state,
+            tz.thermostat_temperature_display_mode,
         ],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);

--- a/devices.js
+++ b/devices.js
@@ -1866,7 +1866,7 @@ const devices = [
         zigbeeModel: ['902010/32'],
         model: 'AV2010/32',
         vendor: 'Bitron',
-        description: 'Video wireless wall thermostat with relay',
+        description: 'Wireless wall thermostat with relay',
         supports: 'temperature, heating/cooling system control',
         fromZigbee: [
             fz.ignore_basic_change, fz.bitron_thermostat_att_report,

--- a/devices.js
+++ b/devices.js
@@ -1866,7 +1866,7 @@ const devices = [
         zigbeeModel: ['902010/32'],
         model: 'AV2010/32',
         vendor: 'Bitron',
-        description: 'Wall thermostat with relay',
+        description: 'Video wireless wall thermostat with relay',
         supports: 'temperature, heating/cooling system control',
         fromZigbee: [
             fz.ignore_basic_change, fz.bitron_thermostat_att_report,

--- a/devices.js
+++ b/devices.js
@@ -1865,23 +1865,31 @@ const devices = [
     {
         zigbeeModel: ['902010/32'],
         model: 'AV2010/32',
-        vendor: 'Bitron Home',
+        vendor: 'Bitron',
         description: 'Wall thermostat with relay',
         supports: 'temperature, heating/cooling system control',
         fromZigbee: [
-            fz.bitron_bitron_battery, fz.bitron_thermostat_att_report,
-            fz.bitron_thermostat_dev_change, fz.ignore_power_change,
+            fz.ignore_basic_change, fz.bitron_thermostat_att_report,
+            fz.bitron_thermostat_dev_change, fz.bitron_battery,
         ],
-        toZigbee: [tz.thermostat_occupied_heating_setpoint, tz.thermostat_local_temperature_calibration],
+        toZigbee: [
+            tz.thermostat_occupied_heating_setpoint, tz.thermostat_local_temperature_calibration,
+            tz.thermostat_local_temperature,
+        ],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);
             const actions = [
+                (cb) => device.bind('genBasic', coordinator, cb),
                 (cb) => device.bind('genPowerCfg', coordinator, cb),
+                (cb) => device.bind('genIdentify', coordinator, cb),
+                (cb) => device.bind('genTime', coordinator, cb),
+                (cb) => device.bind('genPollCtrl', coordinator, cb),
                 (cb) => device.bind('hvacThermostat', coordinator, cb),
+                (cb) => device.bind('hvacUserInterfaceCfg', coordinator, cb),
                 (cb) => device.report('hvacThermostat', 'localTemp', 300, 3600, 0, cb),
-                (cb) => device.report('hvacThermostat', 'local_temperature_calibration', 1, 0, 0, cb),
-                (cb) => device.report('hvacThermostat', 'runningState', 1, 0, 0, cb),
+                (cb) => device.report('hvacThermostat', 'localTemperatureCalibration', 1, 0, 0, cb),
                 (cb) => device.report('hvacThermostat', 'occupiedHeatingSetpoint', 1, 0, 1, cb),
+                (cb) => device.report('hvacThermostat', 'runningState', 1, 0, 0, cb),
                 (cb) => device.report('genPowerCfg', 'batteryVoltage', 1800, 43200, 0, cb),
                 (cb) => device.report('genPowerCfg', 'batteryAlarmState', 1, 0, 1, cb),
             ];

--- a/devices.js
+++ b/devices.js
@@ -1596,7 +1596,7 @@ const devices = [
             return {'left': 12, 'right': 11};
         },
     },
-    
+
     // Gledopto
     {
         zigbeeModel: ['GLEDOPTO', 'GL-C-008', 'GL-C-007'],

--- a/devices.js
+++ b/devices.js
@@ -1596,33 +1596,6 @@ const devices = [
             return {'left': 12, 'right': 11};
         },
     },
-        {
-        zigbeeModel: ['902010/32'],
-        model: 'AV2010/32',
-        vendor: 'Bitron Home',
-        description: 'Wall thermostat with relay',
-        supports: 'temperature, heating/cooling system control',
-        fromZigbee: [
-            fz.bitron_bitron_battery, fz.bitron_thermostat_att_report,
-            fz.bitron_thermostat_dev_change, fz.ignore_power_change,
-        ],
-        toZigbee: [tz.thermostat_occupied_heating_setpoint, tz.thermostat_local_temperature_calibration],
-        configure: (ieeeAddr, shepherd, coordinator, callback) => {
-            const device = shepherd.find(ieeeAddr, 1);
-            const actions = [
-                (cb) => device.bind('genPowerCfg', coordinator, cb),
-                (cb) => device.bind('hvacThermostat', coordinator, cb),
-                (cb) => device.report('hvacThermostat', 'localTemp', 300, 3600, 0, cb),
-                (cb) => device.report('hvacThermostat', 'local_temperature_calibration', 1, 0, 1, cb),
-                (cb) => device.report('hvacThermostat', 'runningState', 1, 0, 0, cb),
-                (cb) => device.report('hvacThermostat', 'occupiedHeatingSetpoint', 1, 0, 1, cb),
-                (cb) => device.report('genPowerCfg', 'batteryVoltage', 1800, 43200, 0, cb),
-                (cb) => device.report('genPowerCfg', 'batteryAlarmState', 1, 0, 1, cb),
-            ];
-
-            execute(device, actions, callback);
-        },
-    },
     
     // Gledopto
     {
@@ -1886,6 +1859,33 @@ const devices = [
                 (cb) => device.report('seMetering', 'instantaneousDemand', 10, 60, 1, cb),
                 (cb) => device.bind('genOnOff', coordinator, cb),
             ];
+            execute(device, actions, callback);
+        },
+    },
+    {
+        zigbeeModel: ['902010/32'],
+        model: 'AV2010/32',
+        vendor: 'Bitron Home',
+        description: 'Wall thermostat with relay',
+        supports: 'temperature, heating/cooling system control',
+        fromZigbee: [
+            fz.bitron_bitron_battery, fz.bitron_thermostat_att_report,
+            fz.bitron_thermostat_dev_change, fz.ignore_power_change,
+        ],
+        toZigbee: [tz.thermostat_occupied_heating_setpoint, tz.thermostat_local_temperature_calibration],
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const device = shepherd.find(ieeeAddr, 1);
+            const actions = [
+                (cb) => device.bind('genPowerCfg', coordinator, cb),
+                (cb) => device.bind('hvacThermostat', coordinator, cb),
+                (cb) => device.report('hvacThermostat', 'localTemp', 300, 3600, 0, cb),
+                (cb) => device.report('hvacThermostat', 'local_temperature_calibration', 1, 0, 0, cb),
+                (cb) => device.report('hvacThermostat', 'runningState', 1, 0, 0, cb),
+                (cb) => device.report('hvacThermostat', 'occupiedHeatingSetpoint', 1, 0, 1, cb),
+                (cb) => device.report('genPowerCfg', 'batteryVoltage', 1800, 43200, 0, cb),
+                (cb) => device.report('genPowerCfg', 'batteryAlarmState', 1, 0, 1, cb),
+            ];
+
             execute(device, actions, callback);
         },
     },

--- a/devices.js
+++ b/devices.js
@@ -1596,7 +1596,33 @@ const devices = [
             return {'left': 12, 'right': 11};
         },
     },
+        {
+        zigbeeModel: ['902010/32'],
+        model: 'AV2010/32',
+        vendor: 'Bitron Home',
+        description: 'Wall thermostat with relay',
+        supports: 'temperature, heating/cooling system control',
+        fromZigbee: [
+            fz.bitron_bitron_battery, fz.bitron_thermostat_att_report,
+            fz.bitron_thermostat_dev_change, fz.ignore_power_change,
+        ],
+        toZigbee: [tz.thermostat_occupied_heating_setpoint, tz.thermostat_local_temperature_calibration],
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const device = shepherd.find(ieeeAddr, 1);
+            const actions = [
+                (cb) => device.bind('genPowerCfg', coordinator, cb),
+                (cb) => device.bind('hvacThermostat', coordinator, cb),
+                (cb) => device.report('hvacThermostat', 'localTemp', 300, 3600, 0, cb),
+                (cb) => device.report('hvacThermostat', 'runningState', 1, 0, 0, cb),
+                (cb) => device.report('hvacThermostat', 'occupiedHeatingSetpoint', 1, 0, 1, cb),
+                (cb) => device.report('genPowerCfg', 'batteryVoltage', 1800, 43200, 0, cb),
+                (cb) => device.report('genPowerCfg', 'batteryAlarmState', 1, 0, 1, cb),
+            ];
 
+            execute(device, actions, callback);
+        },
+    },
+    
     // Gledopto
     {
         zigbeeModel: ['GLEDOPTO', 'GL-C-008', 'GL-C-007'],


### PR DESCRIPTION
as discussed in #134 the new PR for the Bitron Wall thermostat.

fromZigbee:
`fz.bitron_thermostat_att_report `
`fz.bitron_thermostat_dev_change `
**both above result in this without "null" values. e.g.:**
_{
"local_temperature":20.2,
"local_temperature_calibration":0.4,
"occupied_heating_setpoint":21.5,
"linkquality":36,
"battery":"71.43",
"voltage":3000,
"running_state":1
}_
`fz.bitron_battery` **(works for all bitron battery powered devices)**

toZigbee:
`tz.thermostat_occupied_heating_setpoint` **(changed the calculation to use half degrees)**
`tz.thermostat_local_temperature_calibration`
`tz.thermostat_local_temperature`
`tz.thermostat_running_state` **(get the running state)**
`tz.thermostat_temperature_display_mode` **(set display mode to °C or °F)**