### PR TITLE
Update devices.js to include Nue HGZB-01A

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2224,6 +2224,17 @@ const devices = [
         fromZigbee: [fz.generic_state_change],
         toZigbee: [tz.on_off],
     },
+	
+	// Nue	
+	{
+		zigbeeModel: ['FNB56-ZSW23HG1.1'],
+        model: 'HGZB-01A',
+        vendor: 'Nue',
+        description: 'ZigBee Smart Light Controller',
+        supports: generic.light_onoff_brightness.supports,
+        fromZigbee: generic.light_onoff_brightness.fromZigbee,
+        toZigbee: generic.light_onoff_brightness.toZigbee,
+	},
 ];
 
 module.exports = devices;

--- a/devices.js
+++ b/devices.js
@@ -2225,7 +2225,7 @@ const devices = [
         toZigbee: [tz.on_off],
     },
 
-    //Nue
+    // Nue
     {
         zigbeeModel: ['FNB56-ZSW23HG1.1'],
         model: 'HGZB-01A',

--- a/devices.js
+++ b/devices.js
@@ -2224,17 +2224,17 @@ const devices = [
         fromZigbee: [fz.generic_state_change],
         toZigbee: [tz.on_off],
     },
-	
-	//Nue
-	{
-		zigbeeModel: ['FNB56-ZSW23HG1.1'],
+
+    //Nue
+    {
+        zigbeeModel: ['FNB56-ZSW23HG1.1'],
         model: 'HGZB-01A',
         vendor: 'Nue',
         description: 'ZigBee Smart Light Controller',
         supports: generic.light_onoff_brightness.supports,
         fromZigbee: generic.light_onoff_brightness.fromZigbee,
         toZigbee: generic.light_onoff_brightness.toZigbee,
-	},
+    },
 ];
 
 module.exports = devices;

--- a/devices.js
+++ b/devices.js
@@ -1631,6 +1631,15 @@ const devices = [
             return {'left': 12, 'right': 11};
         },
     },
+    {
+        zigbeeModel: ['FNB56-ZSW23HG1.1'],
+        model: 'HGZB-01A',
+        vendor: 'Nue',
+        description: 'ZigBee smart light controller',
+        supports: generic.light_onoff_brightness.supports,
+        fromZigbee: generic.light_onoff_brightness.fromZigbee,
+        toZigbee: generic.light_onoff_brightness.toZigbee,
+    },
 
     // Gledopto
     {
@@ -2223,17 +2232,6 @@ const devices = [
         supports: 'on/off',
         fromZigbee: [fz.generic_state_change],
         toZigbee: [tz.on_off],
-    },
-
-    // Nue
-    {
-        zigbeeModel: ['FNB56-ZSW23HG1.1'],
-        model: 'HGZB-01A',
-        vendor: 'Nue',
-        description: 'ZigBee Smart Light Controller',
-        supports: generic.light_onoff_brightness.supports,
-        fromZigbee: generic.light_onoff_brightness.fromZigbee,
-        toZigbee: generic.light_onoff_brightness.toZigbee,
     },
 ];
 

--- a/devices.js
+++ b/devices.js
@@ -2225,7 +2225,7 @@ const devices = [
         toZigbee: [tz.on_off],
     },
 	
-	// Nue	
+	//Nue
 	{
 		zigbeeModel: ['FNB56-ZSW23HG1.1'],
         model: 'HGZB-01A',


### PR DESCRIPTION
Device is a mains inline zigbee light controller with brightness.
Amazon link:
https://www.amazon.com/gp/product/B07FBD96DG/ref=oh_aui_detailpage_o01_s00?ie=UTF8&psc=1

Added and tested device per: https://koenkk.github.io/zigbee2mqtt/how_tos/how_to_support_new_devices.html