### PR TITLE
Add device support for iCasa Zigbee 3.0 Dimmer

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2271,6 +2271,17 @@ const devices = [
         fromZigbee: generic.light_onoff_brightness_colortemp.fromZigbee,
         toZigbee: generic.light_onoff_brightness_colortemp.toZigbee,
     },
+
+    // iCasa Zigbee 3.0 Dimmer
+    {
+      zigbeeModel: ['ICZB-IW11D'],
+      model: 'ICZB-IW11D',
+      vendor: 'iCasa',
+      description: 'iCasa Zigbee 3.0 Dimmer',
+      supports: generic.light_onoff_brightness().supports,
+      fromZigbee: generic.light_onoff_brightness().fromZigbee,
+      toZigbee: generic.light_onoff_brightness().toZigbee,
+    },
 ];
 
 module.exports = devices;


### PR DESCRIPTION
This commit adds support for iCasa Zigbee 3.0 Dimmer (https://www.wifimedia.eu/nl/icasa-dimmer.html), and most likely also the clones from Sunricher and illuminize but as I do not own them at the moment they will need to be added later. 