### PR TITLE
Fix for: No converter available for 4713407 with cid genOnOff, type a…

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2035,7 +2035,7 @@ const devices = [
         vendor: 'Airam',
         description: 'LED OP A60 ZB 9W/827 E27',
         extend: generic.light_onoff_brightness,
-        fromZigbee: [fz.light_state, fz.light_brightness_report, fz.light_brightness, fz.light_state],
+        fromZigbee: [fz.light_state, fz.light_brightness_report, fz.light_brightness, fz.generic_state],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);
             const cfgOnOff = {direction: 0, attrId: 0, dataType: 16, minRepIntval: 0, maxRepIntval: 1000, repChange: 0};


### PR DESCRIPTION
Got rid of the error:
No converter available for '4713407' with cid 'genOnOff', type 'attReport' and data {"cid":"genOnOff","data":{"onOff":0}}'

I think it was ment to be like this from the beginning since there was double "fz.light_state" on the same row.