### PR TITLE
Initial attempt to add support for OSRAM/Lightify Switch Mini

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -125,27 +125,28 @@ const holdUpdateBrightness324131092621 = (deviceID) => {
 
 
 const converters = {
-  AC0251100NJ_test: {
-    cid: 'genOnOff',
-    type: 'attReport',
-    convert: (model, msg, publish, options) => {
-        console.log(msg.data)
-        },
-    },
-    AC0251100NJ_on: {
-        cid: 'genOnOff',
-        type: 'cmdOn',
-        convert: (model, msg, publish, options) => {
-            return {action: 'on'};
-        },
-    },
-    AC0251100NJ_off: {
-        cid: 'genOnOff',
-        type: 'cmdOff',
-        convert: (model, msg, publish, options) => {
-            return {action: 'off'};
-        },
-    },
+  AC0251100NJ_on: {
+      cid: 'genOnOff',
+      type: 'cmdOn',
+      convert: (model, msg, publish, options) => {
+          return {click: 'on'};
+      },
+  },
+  AC0251100NJ_off: {
+      cid: 'genOnOff',
+      type: 'cmdOff',
+      convert: (model, msg, publish, options) => {
+          return {click: 'off'};
+      },
+  },
+  AC0251100NJ_long_middle: {
+      cid: 'lightingColorCtrl',
+      type: 'cmdMoveHue',
+      convert: (model, msg, publish, options) => {
+      //'cmdMoveHue' with data '{"cid":"lightingColorCtrl","data":{"movemode":0,"rate":0}}'
+          return {click: 'long_middle'};
+      },
+  },
     bitron_power: {
         cid: 'seMetering',
         type: 'attReport',

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1046,7 +1046,7 @@ const converters = {
             return {presence: true};
         },
     },
-    STS_PRS_251_battery: {
+    generic_batteryvoltage_3000_2500: {
         cid: 'genPowerCfg',
         type: 'attReport',
         convert: (model, msg, publish, options) => {
@@ -1146,27 +1146,27 @@ const converters = {
             return {voltage: msg.data.data['batteryVoltage'] / 100};
         },
     },
-    ICTC_G_1_move: {
+    cmd_move: {
         cid: 'genLevelCtrl',
         type: 'cmdMove',
         convert: (model, msg, publish, options) => ictcg1(model, msg, publish, options, 'move'),
     },
-    ICTC_G_1_moveWithOnOff: {
+    cmd_move_with_onoff: {
         cid: 'genLevelCtrl',
         type: 'cmdMoveWithOnOff',
         convert: (model, msg, publish, options) => ictcg1(model, msg, publish, options, 'move'),
     },
-    ICTC_G_1_stop: {
+    cmd_stop: {
         cid: 'genLevelCtrl',
         type: 'cmdStop',
         convert: (model, msg, publish, options) => ictcg1(model, msg, publish, options, 'stop'),
     },
-    ICTC_G_1_stopWithOnOff: {
+    cmd_stop_with_onoff: {
         cid: 'genLevelCtrl',
         type: 'cmdStopWithOnOff',
         convert: (model, msg, publish, options) => ictcg1(model, msg, publish, options, 'stop'),
     },
-    ICTC_G_1_moveToLevelWithOnOff: {
+    cmd_move_to_level_with_onoff: {
         cid: 'genLevelCtrl',
         type: 'cmdMoveToLevelWithOnOff',
         convert: (model, msg, publish, options) => ictcg1(model, msg, publish, options, 'level'),

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -143,7 +143,6 @@ const converters = {
         cid: 'lightingColorCtrl',
         type: 'cmdMoveHue',
         convert: (model, msg, publish, options) => {
-        // 'cmdMoveHue' with data '{"cid":"lightingColorCtrl","data":{"movemode":0,"rate":0}}'
             return {click: 'long_middle'};
         },
     },

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -125,6 +125,27 @@ const holdUpdateBrightness324131092621 = (deviceID) => {
 
 
 const converters = {
+  AC0251100NJ_test: {
+    cid: 'genOnOff',
+    type: 'attReport',
+    convert: (model, msg, publish, options) => {
+        console.log(msg.data)
+        },
+    },
+    AC0251100NJ_on: {
+        cid: 'genOnOff',
+        type: 'cmdOn',
+        convert: (model, msg, publish, options) => {
+            return {action: 'on'};
+        },
+    },
+    AC0251100NJ_off: {
+        cid: 'genOnOff',
+        type: 'cmdOff',
+        convert: (model, msg, publish, options) => {
+            return {action: 'off'};
+        },
+    },
     bitron_power: {
         cid: 'seMetering',
         type: 'attReport',

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -125,28 +125,28 @@ const holdUpdateBrightness324131092621 = (deviceID) => {
 
 
 const converters = {
-  AC0251100NJ_on: {
-      cid: 'genOnOff',
-      type: 'cmdOn',
-      convert: (model, msg, publish, options) => {
-          return {click: 'on'};
-      },
-  },
-  AC0251100NJ_off: {
-      cid: 'genOnOff',
-      type: 'cmdOff',
-      convert: (model, msg, publish, options) => {
-          return {click: 'off'};
-      },
-  },
-  AC0251100NJ_long_middle: {
-      cid: 'lightingColorCtrl',
-      type: 'cmdMoveHue',
-      convert: (model, msg, publish, options) => {
-      //'cmdMoveHue' with data '{"cid":"lightingColorCtrl","data":{"movemode":0,"rate":0}}'
-          return {click: 'long_middle'};
-      },
-  },
+    AC0251100NJ_on: {
+        cid: 'genOnOff',
+        type: 'cmdOn',
+        convert: (model, msg, publish, options) => {
+            return {click: 'on'};
+        },
+    },
+    AC0251100NJ_off: {
+        cid: 'genOnOff',
+        type: 'cmdOff',
+        convert: (model, msg, publish, options) => {
+            return {click: 'off'};
+        },
+    },
+    AC0251100NJ_long_middle: {
+        cid: 'lightingColorCtrl',
+        type: 'cmdMoveHue',
+        convert: (model, msg, publish, options) => {
+        // 'cmdMoveHue' with data '{"cid":"lightingColorCtrl","data":{"movemode":0,"rate":0}}'
+            return {click: 'long_middle'};
+        },
+    },
     bitron_power: {
         cid: 'seMetering',
         type: 'attReport',

--- a/devices.js
+++ b/devices.js
@@ -1625,7 +1625,10 @@ const devices = [
         vendor: 'SmartThings',
         description: 'Arrival sensor',
         supports: 'presence',
-        fromZigbee: [fz.STS_PRS_251_presence, fz.generic_batteryvoltage_3000_2500, fz.ignore_power_change, fz.STS_PRS_251_beeping],
+        fromZigbee: [
+            fz.STS_PRS_251_presence, fz.generic_batteryvoltage_3000_2500, fz.ignore_power_change, 
+            fz.STS_PRS_251_beeping,
+        ],
         toZigbee: [tz.STS_PRS_251_beep],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);

--- a/devices.js
+++ b/devices.js
@@ -1059,6 +1059,28 @@ const devices = [
         description: 'SMART+ spot GU5.3 tunable white',
         extend: generic.light_onoff_brightness_colortemp,
     },
+    ,
+    {
+        zigbeeModel: ['Lightify Switch Mini', 'Lightify Switch Mini\u0000'],
+        model: 'AC0251100NJ',
+        vendor: 'OSRAM',
+        description: 'Smart+ Switch Mini',
+        supports: 'ToDo',
+        fromZigbee: [fz.AC0251100NJ_off, fz.AC0251100NJ_on,fz.ICTC_G_1_stop,fz.ICTC_G_1_move,fz.ICTC_G_1_moveWithOnOff,fz.ICTC_G_1_moveToLevelWithOnOff, fz.STS_PRS_251_battery],
+        toZigbee: [],
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const device = shepherd.find(ieeeAddr, 1);
+            const actions = [
+                (cb) => device.bind('genOnOff', coordinator, cb),
+                (cb) => device.bind('lightingColorCtrl', coordinator, cb),
+                (cb) => device.bind('genLevelCtrl', coordinator, cb),
+                (cb) => device.bind('genPowerCfg', coordinator, cb),
+                (cb) => device.report('genPowerCfg', 'batteryVoltage', 300, 3600, 0, cb),
+            ];
+             execute(device, actions, callback);
+        },
+
+    },
 
     // Hive
     {

--- a/devices.js
+++ b/devices.js
@@ -1068,7 +1068,7 @@ const devices = [
         fromZigbee: [
             fz.AC0251100NJ_on, fz.AC0251100NJ_off, fz.AC0251100NJ_long_middle,
             fz.ICTC_G_1_stop, fz.ICTC_G_1_move, fz.ICTC_G_1_moveWithOnOff,
-            fz.ICTC_G_1_moveToLevelWithOnOff, fz.STS_PRS_251_battery, 
+            fz.ICTC_G_1_moveToLevelWithOnOff, fz.STS_PRS_251_battery,
         ],
         toZigbee: [],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {

--- a/devices.js
+++ b/devices.js
@@ -1068,7 +1068,7 @@ const devices = [
         fromZigbee: [
             fz.AC0251100NJ_on, fz.AC0251100NJ_off, fz.AC0251100NJ_long_middle,
             fz.ICTC_G_1_stop, fz.ICTC_G_1_move, fz.ICTC_G_1_moveWithOnOff,
-            fz.ICTC_G_1_moveToLevelWithOnOff, fz.STS_PRS_251_battery
+            fz.ICTC_G_1_moveToLevelWithOnOff, fz.STS_PRS_251_battery, 
         ],
         toZigbee: [],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {

--- a/devices.js
+++ b/devices.js
@@ -471,8 +471,8 @@ const devices = [
         description: 'TRADFRI wireless dimmer',
         supports: 'brightness [0-255], quick rotate for instant 0/255',
         fromZigbee: [
-            fz.ICTC_G_1_move, fz.ICTC_G_1_moveWithOnOff, fz.ICTC_G_1_stop, fz.ICTC_G_1_stopWithOnOff,
-            fz.ICTC_G_1_moveToLevelWithOnOff, fz.generic_battery, fz.ignore_power_change,
+            fz.cmd_move, fz.cmd_move_with_onoff, fz.cmd_stop, fz.cmd_stop_with_onoff,
+            fz.cmd_move_to_level_with_onoff, fz.generic_battery, fz.ignore_power_change,
         ],
         toZigbee: [],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
@@ -1063,12 +1063,12 @@ const devices = [
         zigbeeModel: ['Lightify Switch Mini', 'Lightify Switch Mini\u0000'],
         model: 'AC0251100NJ',
         vendor: 'OSRAM',
-        description: 'Smart+ Switch Mini',
+        description: 'Smart+ switch mini',
         supports: 'on/off, brightness',
         fromZigbee: [
             fz.AC0251100NJ_on, fz.AC0251100NJ_off, fz.AC0251100NJ_long_middle,
-            fz.ICTC_G_1_stop, fz.ICTC_G_1_move, fz.ICTC_G_1_moveWithOnOff,
-            fz.ICTC_G_1_moveToLevelWithOnOff, fz.STS_PRS_251_battery,
+            fz.cmd_stop, fz.cmd_move, fz.cmd_move_with_onoff,
+            fz.cmd_move_to_level_with_onoff, fz.generic_batteryvoltage_3000_2500,
         ],
         toZigbee: [],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
@@ -1625,7 +1625,7 @@ const devices = [
         vendor: 'SmartThings',
         description: 'Arrival sensor',
         supports: 'presence',
-        fromZigbee: [fz.STS_PRS_251_presence, fz.STS_PRS_251_battery, fz.ignore_power_change, fz.STS_PRS_251_beeping],
+        fromZigbee: [fz.STS_PRS_251_presence, fz.generic_batteryvoltage_3000_2500, fz.ignore_power_change, fz.STS_PRS_251_beeping],
         toZigbee: [tz.STS_PRS_251_beep],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);

--- a/devices.js
+++ b/devices.js
@@ -1059,14 +1059,13 @@ const devices = [
         description: 'SMART+ spot GU5.3 tunable white',
         extend: generic.light_onoff_brightness_colortemp,
     },
-    ,
     {
         zigbeeModel: ['Lightify Switch Mini', 'Lightify Switch Mini\u0000'],
         model: 'AC0251100NJ',
         vendor: 'OSRAM',
         description: 'Smart+ Switch Mini',
-        supports: 'ToDo',
-        fromZigbee: [fz.AC0251100NJ_off, fz.AC0251100NJ_on,fz.ICTC_G_1_stop,fz.ICTC_G_1_move,fz.ICTC_G_1_moveWithOnOff,fz.ICTC_G_1_moveToLevelWithOnOff, fz.STS_PRS_251_battery],
+        supports: 'on/off, brightness',
+        fromZigbee: [fz.AC0251100NJ_on, fz.AC0251100NJ_off,fz.AC0251100NJ_long_middle,fz.ICTC_G_1_stop,fz.ICTC_G_1_move,fz.ICTC_G_1_moveWithOnOff,fz.ICTC_G_1_moveToLevelWithOnOff, fz.STS_PRS_251_battery],
         toZigbee: [],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);
@@ -1075,7 +1074,7 @@ const devices = [
                 (cb) => device.bind('lightingColorCtrl', coordinator, cb),
                 (cb) => device.bind('genLevelCtrl', coordinator, cb),
                 (cb) => device.bind('genPowerCfg', coordinator, cb),
-                (cb) => device.report('genPowerCfg', 'batteryVoltage', 300, 3600, 0, cb),
+                (cb) => device.report('genPowerCfg', 'batteryVoltage', 900, 3600, 0, cb),
             ];
              execute(device, actions, callback);
         },

--- a/devices.js
+++ b/devices.js
@@ -1626,7 +1626,7 @@ const devices = [
         description: 'Arrival sensor',
         supports: 'presence',
         fromZigbee: [
-            fz.STS_PRS_251_presence, fz.generic_batteryvoltage_3000_2500, fz.ignore_power_change, 
+            fz.STS_PRS_251_presence, fz.generic_batteryvoltage_3000_2500, fz.ignore_power_change,
             fz.STS_PRS_251_beeping,
         ],
         toZigbee: [tz.STS_PRS_251_beep],

--- a/devices.js
+++ b/devices.js
@@ -1065,7 +1065,11 @@ const devices = [
         vendor: 'OSRAM',
         description: 'Smart+ Switch Mini',
         supports: 'on/off, brightness',
-        fromZigbee: [fz.AC0251100NJ_on, fz.AC0251100NJ_off,fz.AC0251100NJ_long_middle,fz.ICTC_G_1_stop,fz.ICTC_G_1_move,fz.ICTC_G_1_moveWithOnOff,fz.ICTC_G_1_moveToLevelWithOnOff, fz.STS_PRS_251_battery],
+        fromZigbee: [
+            fz.AC0251100NJ_on, fz.AC0251100NJ_off, fz.AC0251100NJ_long_middle,
+            fz.ICTC_G_1_stop, fz.ICTC_G_1_move, fz.ICTC_G_1_moveWithOnOff,
+            fz.ICTC_G_1_moveToLevelWithOnOff, fz.STS_PRS_251_battery
+        ],
         toZigbee: [],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);
@@ -1076,7 +1080,7 @@ const devices = [
                 (cb) => device.bind('genPowerCfg', coordinator, cb),
                 (cb) => device.report('genPowerCfg', 'batteryVoltage', 900, 3600, 0, cb),
             ];
-             execute(device, actions, callback);
+            execute(device, actions, callback);
         },
 
     },


### PR DESCRIPTION
Continuation of the work done by @pixeldoc2000.  With a flittle more progress hopefully.

For reference by default when paired directly with a RGBCCD bulb the button perform as below:

Short Up : On to Last Setting
Long Up: Increase brightness
Middle/Circle: On to White  255 Brightness
Long Middle/Circle:  Colour Cycle
Short Down: Off
Long Down: Decrease brightness

Pairing on this device seems to be 3-5sec hold of Middle and UP.

Currently have issue where although remote commands are seen correctly by zigbee2mqtt remote seem to be working as master switch and control all lights at once.  