### PR TITLE
Fix xiaomi lock

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -769,7 +769,7 @@ const converters = {
                         return {keyerror: true, inserted: 'unknown'};
                     }
                     if (action == 3) {
-                        // explicitly disabled key (e.g.: reported lost)
+                        // explicitly disabled key (i.e. reported lost)
                         return {keyerror: true, inserted: keynum};
                     }
                     if (action == 7) {

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -772,6 +772,10 @@ const converters = {
                         // explicitly disabled key (e.g.: reported lost)
                         return {keyerror: true, inserted: keynum};
                     }
+                    if (action == 7) {
+                        // strange object introduced into the cylinder (e.g. a lock pick)
+                        return {keyerror: true, inserted: 'strange'};
+                    }
                 }
                 if (state == 12) {
                     if (action == 1) {


### PR DESCRIPTION
As @qm3ster pointed out in https://github.com/Koenkk/zigbee-shepherd-converters/pull/138#commitcomment-31625554, my PR #138 removed handling of the case in which action is `7` and not `1` or `3`.

My reasoning for the removal was that I hadn't been able to reproduce the `7` action (`{"cid":"genBasic","data":{"65328":"0x1107ffffffffffff"}}`) with my lock, which made me suspect that such action existed in the past but Xiaomi removed it at some point through a firmware update.

However, I have eventually been able to get the `7` action with my lock, which has made me reconsider my previous assumptions. As expected, `7` means that some strange object has been introduced into the cylinder.

This PR recovers the logic for handling the `7` action, which is now bubbled up as `{keyerror: true, inserted: 'strange'}`.