### PR TITLE
Support for RGB Mueller Licht: tint

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2123,6 +2123,15 @@ const devices = [
         description: 'Zigbee 3.0 Dimmer',
         extend: generic.light_onoff_brightness,
     },
+
+    // Mueller Licht tint
+    {
+        zigbeeModel: ['ZBT-ExtendedColor'],
+        model: '404000/404005/404012',
+        vendor: 'MuellerLicht',
+        description: 'tint LED bulb GU10/E14/E27 350/470/806 lumen, dimmable, color, opal white',
+        extend: generic.light_onoff_brightness_colortemp_colorxy,
+    },
 ];
 
 module.exports = devices.map((device) =>

--- a/devices.js
+++ b/devices.js
@@ -2124,12 +2124,12 @@ const devices = [
         extend: generic.light_onoff_brightness,
     },
 
-    // Mueller Licht tint
+    // Müller Licht
     {
         zigbeeModel: ['ZBT-ExtendedColor'],
         model: '404000/404005/404012',
-        vendor: 'MuellerLicht',
-        description: 'tint LED bulb GU10/E14/E27 350/470/806 lumen, dimmable, color, opal white',
+        vendor: 'Müller Licht',
+        description: 'Tint LED bulb GU10/E14/E27 350/470/806 lumen, dimmable, color, opal white',
         extend: generic.light_onoff_brightness_colortemp_colorxy,
     },
 ];


### PR DESCRIPTION
Since today are smart bulbs at discount from the german company "Müller Licht" available at Aldi Nord.
I added support for my GU-10 RGB-Version and tested it with zigbee2mqtt.

https://www.aldi-nord.de/angebote/angebote-mo-21-01/smart-light-erweiterungslampe-color-1000816.article.html