### PR TITLE
Add support for AduroSmart ERIA White and Color bulbs.

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2249,7 +2249,7 @@ const devices = [
         zigbeeModel: ['ZLL-ExtendedColo'],
         model: '81809',
         vendor: 'AduroSmart',
-        description: 'ERIA Colors and White Shades Smart Light Bulb A19',
+        description: 'ERIA colors and white shades smart light bulb A19',
         extend: generic.light_onoff_brightness_colortemp_colorxy,
         ep: (device) => {
             return {

--- a/devices.js
+++ b/devices.js
@@ -2243,6 +2243,20 @@ const devices = [
             execute(device, actions, callback);
         },
     },
+
+    // AduroSmart
+    {
+        zigbeeModel: ['ZLL-ExtendedColo'],
+        model: '81809',
+        vendor: 'AduroSmart',
+        description: 'ERIA Colors and White Shades Smart Light Bulb A19',
+        extend: generic.light_onoff_brightness_colortemp_colorxy,
+        ep: (device) => {
+            return {
+                '': 2,
+            };
+        },
+    },
 ];
 
 module.exports = devices.map((device) =>


### PR DESCRIPTION
More information on the specific lamp I've tested this with: https://adurosmart.com/products/adurosmart-eria-smart-bulb-a19-white-and-color-dimmable-cri-90-60w-equivalent-hub-required (some good high-res images there)

All functionality works (brightness, color temperature, colorxy). However, after setting a state the lamp doesn't automatically send an update; hence, no update is sent on MQTT (and to Home Assistant if you use that). Publishing on the relevant `get` topic does trigger the lamp to send updated information. I think ideally we should automatically trigger a get after a set. Happy to hear how to do that best and adapt this PR. (My idea is to use  the transtime / readAfterWriteTime setting, but there might be something better)

This implements one of two new devices mentioned in https://github.com/Koenkk/zigbee2mqtt/issues/939