### PR TITLE
Added Eurotronic Spirit Zigbee thermostat

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1444,28 +1444,10 @@ const converters = {
                     precisionRound(msg.data.data[16387], 2) / 100;
             }
             if (typeof msg.data.data[16392] == 'number') {
-                result.spzb_system_mode = msg.data.data[16392];
+                result.eurotronic_system_mode = msg.data.data[16392];
             }
             if (typeof msg.data.data[16386] == 'number') {
-                result.spzb_16386 = msg.data.data[16386];
-            }
-            return result;
-        },
-    },
-    eurotronic_thermostat_dev_change: {
-        cid: 'hvacThermostat',
-        type: 'devChange',
-        convert: (model, msg, publish, options) => {
-            const result = {};
-            if (typeof msg.data.data[16387] == 'number') {
-                result.current_heating_setpoint =
-                    precisionRound(msg.data.data[16387], 2) / 100;
-            }
-            if (typeof msg.data.data[16392] == 'number') {
-                result.spzb_system_mode = msg.data.data[16392];
-            }
-            if (typeof msg.data.data[16386] == 'number') {
-                result.spzb_16386 = msg.data.data[16386];
+                result.eurotronic_16386 = msg.data.data[16386];
             }
             return result;
         },
@@ -1647,6 +1629,11 @@ const converters = {
     ignore_closuresWindowCovering_report: {
         cid: 'closuresWindowCovering',
         type: 'attReport',
+        convert: (model, msg, publish, options) => null,
+    },
+    ignore_thermostat_change: {
+        cid: 'hvacThermostat',
+        type: 'devChange',
         convert: (model, msg, publish, options) => null,
     },
 };

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1368,6 +1368,9 @@ const converters = {
             if (typeof state == 'number' && common.thermostatRunningStates.hasOwnProperty(state)) {
                 result.running_state = common.thermostatRunningStates[state];
             }
+            if (typeof msg.data.data['pIHeatingDemand'] == 'number') {
+                result.pi_heating_demand = msg.data.data['pIHeatingDemand'];
+            }
             return result;
         },
     },
@@ -1425,6 +1428,9 @@ const converters = {
             if (typeof state == 'number' && common.thermostatRunningStates.hasOwnProperty(state)) {
                 result.running_state = common.thermostatRunningStates[state];
             }
+            if (typeof msg.data.data['pIHeatingDemand'] == 'number') {
+                result.pi_heating_demand = msg.data.data['pIHeatingDemand'];
+            }
             return result;
         },
     },
@@ -1433,30 +1439,15 @@ const converters = {
         type: 'attReport',
         convert: (model, msg, publish, options) => {
             const result = {};
-            if (typeof msg.data.data['localTemp'] == 'number') {
-                result.local_temperature = precisionRound(msg.data.data['localTemp'], 2) / 100;
-            }
-            if (typeof msg.data.data['localTemperatureCalibration'] == 'number') {
-                result.local_temperature_calibration =
-                    precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10;
-            }
-            if (typeof msg.data.data['occupiedHeatingSetpoint'] == 'number') {
-                result.occupied_heating_setpoint =
-                    precisionRound(msg.data.data['occupiedHeatingSetpoint'], 2) / 100;
-            }
-            if (typeof msg.data.data['unoccupiedHeatingSetpoint'] == 'number') {
-                result.unoccupied_heating_setpoint =
-                    precisionRound(msg.data.data['unoccupiedHeatingSetpoint'], 2) / 100;
-            }
-            if (typeof msg.data.data['setpointChangeAmount'] == 'number') {
-                result.setpoint_change_amount = msg.data.data['setpointChangeAmount'] / 100;
-            }
-            if (typeof msg.data.data['pIHeatingDemand'] == 'number') {
-                result.pi_heating_demand = msg.data.data['pIHeatingDemand'];
-            }
             if (typeof msg.data.data[16387] == 'number') {
                 result.current_heating_setpoint =
                     precisionRound(msg.data.data[16387], 2) / 100;
+            }
+            if (typeof msg.data.data[16392] == 'number') {
+                result.spzb_system_mode = msg.data.data[16392];
+            }
+            if (typeof msg.data.data[16386] == 'number') {
+                result.spzb_16386 = msg.data.data[16386];
             }
             return result;
         },
@@ -1466,38 +1457,15 @@ const converters = {
         type: 'devChange',
         convert: (model, msg, publish, options) => {
             const result = {};
-            if (typeof msg.data.data['localTemp'] == 'number') {
-                result.local_temperature = precisionRound(msg.data.data['localTemp'], 2) / 100;
-            }
-            if (typeof msg.data.data['localTemperatureCalibration'] == 'number') {
-                result.local_temperature_calibration =
-                    precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10;
-            }
-            if (typeof msg.data.data['occupiedHeatingSetpoint'] == 'number') {
-                result.occupied_heating_setpoint =
-                    precisionRound(msg.data.data['occupiedHeatingSetpoint'], 2) / 100;
-            }
-            if (typeof msg.data.data['unoccupiedHeatingSetpoint'] == 'number') {
-                result.unoccupied_heating_setpoint =
-                    precisionRound(msg.data.data['unoccupiedHeatingSetpoint'], 2) / 100;
-            }
-            if (typeof msg.data.data['pIHeatingDemand'] == 'number') {
-                result.pi_heating_demand = msg.data.data['pIHeatingDemand'];
-            }
             if (typeof msg.data.data[16387] == 'number') {
                 result.current_heating_setpoint =
                     precisionRound(msg.data.data[16387], 2) / 100;
             }
-            return result;
-        },
-    },
-    eurotronic_battery_dev_change: {
-        cid: 'genPowerCfg',
-        type: 'devChange',
-        convert: (model, msg, publish, options) => {
-            const result = {};
-            if (typeof msg.data.data['batteryPercentageRemaining'] == 'number') {
-                return {battery: precisionRound(msg.data.data['batteryPercentageRemaining'], 2) / 2};
+            if (typeof msg.data.data[16392] == 'number') {
+                result.spzb_system_mode = msg.data.data[16392];
+            }
+            if (typeof msg.data.data[16386] == 'number') {
+                result.spzb_16386 = msg.data.data[16386];
             }
             return result;
         },

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1428,6 +1428,80 @@ const converters = {
             return result;
         },
     },
+    eurotronic_thermostat_att_report: {
+        cid: 'hvacThermostat',
+        type: 'attReport',
+        convert: (model, msg, publish, options) => {
+            const result = {};
+            if (typeof msg.data.data['localTemp'] == 'number') {
+                result.local_temperature = precisionRound(msg.data.data['localTemp'], 2) / 100;
+            }
+            if (typeof msg.data.data['localTemperatureCalibration'] == 'number') {
+                result.local_temperature_calibration =
+                    precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10;
+            }
+            if (typeof msg.data.data['occupiedHeatingSetpoint'] == 'number') {
+                result.occupied_heating_setpoint =
+                    precisionRound(msg.data.data['occupiedHeatingSetpoint'], 2) / 100;
+            }
+            if (typeof msg.data.data['unoccupiedHeatingSetpoint'] == 'number') {
+                result.unoccupied_heating_setpoint =
+                    precisionRound(msg.data.data['unoccupiedHeatingSetpoint'], 2) / 100;
+            }
+            if (typeof msg.data.data['setpointChangeAmount'] == 'number') {
+                result.setpoint_change_amount = msg.data.data['setpointChangeAmount'] / 100;
+            }
+            if (typeof msg.data.data['pIHeatingDemand'] == 'number') {
+                result.pi_heating_demand = msg.data.data['pIHeatingDemand'];
+            }
+            if (typeof msg.data.data[16387] == 'number') {
+                result.current_heating_setpoint =
+                    precisionRound(msg.data.data[16387], 2) / 100;
+            }
+            return result;
+        },
+    },
+    eurotronic_thermostat_dev_change: {
+        cid: 'hvacThermostat',
+        type: 'devChange',
+        convert: (model, msg, publish, options) => {
+            const result = {};
+            if (typeof msg.data.data['localTemp'] == 'number') {
+                result.local_temperature = precisionRound(msg.data.data['localTemp'], 2) / 100;
+            }
+            if (typeof msg.data.data['localTemperatureCalibration'] == 'number') {
+                result.local_temperature_calibration =
+                    precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10;
+            }
+            if (typeof msg.data.data['occupiedHeatingSetpoint'] == 'number') {
+                result.occupied_heating_setpoint =
+                    precisionRound(msg.data.data['occupiedHeatingSetpoint'], 2) / 100;
+            }
+            if (typeof msg.data.data['unoccupiedHeatingSetpoint'] == 'number') {
+                result.unoccupied_heating_setpoint =
+                    precisionRound(msg.data.data['unoccupiedHeatingSetpoint'], 2) / 100;
+            }
+            if (typeof msg.data.data['pIHeatingDemand'] == 'number') {
+                result.pi_heating_demand = msg.data.data['pIHeatingDemand'];
+            }
+            if (typeof msg.data.data[16387] == 'number') {
+                result.current_heating_setpoint =
+                    precisionRound(msg.data.data[16387], 2) / 100;
+            }
+            return result;
+        },
+    },
+    eurotronic_battery_dev_change: {
+        cid: 'genPowerCfg',
+        type: 'devChange',
+        convert: (model, msg, publish, options) => {
+            const result = {};
+            if (typeof msg.data.data['batteryPercentageRemaining'] == 'number') {
+                return {battery: precisionRound(msg.data.data['batteryPercentageRemaining'], 2) / 2};
+            }
+            return result;
+        },
+    },
     E1524_toggle: {
         cid: 'genOnOff',
         type: 'cmdToggle',

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -938,7 +938,7 @@ const converters = {
                 return {
                     cid: cid,
                     cmd: 'read',
-                    cmdType: 'foundation',              
+                    cmdType: 'foundation',
                     zclData: [{attrId: attrId}],
                     cfg: cfg.eurotronic,
                 };

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -886,8 +886,8 @@ const converters = {
             };
         },
     },
-    spzb0001_system_mode: {
-        key: 'spzb_system_mode',
+    eurotronic_system_mode: {
+        key: 'eurotronic_system_mode',
         convert: (key, value, message, type) => {
             const cid = 'hvacThermostat';
             const attrId = 16392;
@@ -917,8 +917,8 @@ const converters = {
             }
         },
     },
-    spzb0001_16386: {
-        key: 'spzb_16386',
+    eurotronic_16386: {
+        key: 'eurotronic_16386',
         convert: (key, value, message, type) => {
             const cid = 'hvacThermostat';
             const attrId = 16386;
@@ -929,7 +929,7 @@ const converters = {
                     cmdType: 'foundation',
                     zclData: [{
                         attrId: attrId,
-                        dataType: 0x22,
+                        dataType: 0x20,
                         attrData: value,
                     }],
                     cfg: cfg.eurotronic,

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -14,6 +14,10 @@ const cfg = {
         disDefaultRsp: 1,
         manufCode: 0x115F,
     },
+    eurotronic: { 
+        manufSpec: 1,
+        manufCode: 4151, 
+    },
 };
 
 const converters = {
@@ -880,6 +884,65 @@ const converters = {
                 }],
                 cfg: cfg.default,
             };
+        },
+    },
+    spzb0001_system_mode: {
+        key: 'spzb_system_mode',
+        convert: (key, value, message, type) => {
+            const cid = 'hvacThermostat';
+            const attrId = 16392;
+            if (type === 'set') {
+                return {
+                    cid: cid,
+                    cmd: 'write',
+                    cmdType: 'foundation',
+                    zclData: [{
+                        // Bit 0 = ? (default 1)
+                        // Bit 2 = Boost
+                        // Bit 7 = Child protection
+                        attrId: attrId,
+                        dataType: 0x22,
+                        attrData: value,
+                    }],
+                    cfg: cfg.eurotronic,
+                };
+            } else if (type === 'get') {
+                return {
+                    cid: cid,
+                    cmd: 'read',
+                    cmdType: 'foundation',
+                    zclData: [{attrId: attrId}],
+                    cfg: cfg.eurotronic,
+                };
+            }
+        },
+    },
+    spzb0001_16386: {
+        key: 'spzb_16386',
+        convert: (key, value, message, type) => {
+            const cid = 'hvacThermostat';
+            const attrId = 16386;
+            if (type === 'set') {
+                return {
+                    cid: cid,
+                    cmd: 'write',
+                    cmdType: 'foundation',
+                    zclData: [{
+                        attrId: attrId,
+                        dataType: 0x22,
+                        attrData: value,
+                    }],
+                    cfg: cfg.eurotronic,
+                };
+            } else if (type === 'get') {
+                return {
+                    cid: cid,
+                    cmd: 'read',
+                    cmdType: 'foundation',
+                    zclData: [{attrId: attrId}],
+                    cfg: cfg.eurotronic,
+                };
+            }
         },
     },
 

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -888,7 +888,7 @@ const converters = {
     },
     eurotronic_system_mode: {
         key: 'eurotronic_system_mode',
-        convert: (key, value, message, type) => {
+        convert: (key, value, message, type, postfix) => {
             const cid = 'hvacThermostat';
             const attrId = 16392;
             if (type === 'set') {
@@ -919,7 +919,7 @@ const converters = {
     },
     eurotronic_16386: {
         key: 'eurotronic_16386',
-        convert: (key, value, message, type) => {
+        convert: (key, value, message, type, postfix) => {
             const cid = 'hvacThermostat';
             const attrId = 16386;
             if (type === 'set') {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -14,9 +14,9 @@ const cfg = {
         disDefaultRsp: 1,
         manufCode: 0x115F,
     },
-    eurotronic: { 
+    eurotronic: {
         manufSpec: 1,
-        manufCode: 4151, 
+        manufCode: 4151,
     },
 };
 

--- a/devices.js
+++ b/devices.js
@@ -2283,8 +2283,8 @@ const devices = [
         supports: 'temperature, heating system control',
         fromZigbee: [
             fz.ignore_basic_change, fz.thermostat_att_report, fz.thermostat_dev_change,
-            fz.eurotronic_thermostat_att_report, fz.eurotronic_thermostat_dev_change, 
-            fz.hue_battery
+            fz.eurotronic_thermostat_att_report, fz.eurotronic_thermostat_dev_change,
+            fz.hue_battery,
         ],
         toZigbee: [
             tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,

--- a/devices.js
+++ b/devices.js
@@ -2282,25 +2282,22 @@ const devices = [
         description: 'Wireless heater thermostat',
         supports: 'temperature, heating system control',
         fromZigbee: [
-            fz.ignore_basic_change, fz.eurotronic_thermostat_att_report,
-            fz.eurotronic_thermostat_dev_change, fz.hue_battery, fz.eurotronic_battery_dev_change,
+            fz.ignore_basic_change, fz.thermostat_att_report, fz.thermostat_dev_change,
+            fz.eurotronic_thermostat_att_report, fz.eurotronic_thermostat_dev_change, 
+            fz.hue_battery
         ],
         toZigbee: [
             tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,
-            tz.thermostat_local_temperature_calibration,
+            tz.thermostat_local_temperature_calibration, tz.thermostat_system_mode,
+            tz.spzb0001_system_mode, tz.spzb0001_16386,
         ],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);
             const actions = [
                 (cb) => device.bind('genBasic', coordinator, cb),
                 (cb) => device.bind('genPowerCfg', coordinator, cb),
-                (cb) => device.bind('genIdentify', coordinator, cb),
-                (cb) => device.bind('genTime', coordinator, cb),
-                (cb) => device.bind('genPollCtrl', coordinator, cb),
                 (cb) => device.bind('hvacThermostat', coordinator, cb),
-                (cb) => device.report('hvacThermostat', 'localTemp', 300, 3600, 0, cb),
-                (cb) => device.report('hvacThermostat', 'pIHeatingDemand', 1, 0, 1, cb),
-                (cb) => device.report('genPowerCfg', 'batteryPercentageRemaining', 300, 3600, 0, cb),
+                (cb) => device.report('hvacThermostat', 'localTemp', 1, 1200, 25, cb),
             ];
 
             execute(device, actions, callback);

--- a/devices.js
+++ b/devices.js
@@ -2273,6 +2273,39 @@ const devices = [
             };
         },
     },
+
+    // Eurotronic
+    {
+        zigbeeModel: ['SPZB0001'],
+        model: 'Spirit Zigbee (SPZB0001)',
+        vendor: 'Eurotronic',
+        description: 'Wireless heater thermostat',
+        supports: 'temperature, heating system control',
+        fromZigbee: [
+            fz.ignore_basic_change, fz.eurotronic_thermostat_att_report,
+            fz.eurotronic_thermostat_dev_change, fz.hue_battery, fz.eurotronic_battery_dev_change,
+        ],
+        toZigbee: [
+            tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,
+            tz.thermostat_local_temperature_calibration,
+        ],
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const device = shepherd.find(ieeeAddr, 1);
+            const actions = [
+                (cb) => device.bind('genBasic', coordinator, cb),
+                (cb) => device.bind('genPowerCfg', coordinator, cb),
+                (cb) => device.bind('genIdentify', coordinator, cb),
+                (cb) => device.bind('genTime', coordinator, cb),
+                (cb) => device.bind('genPollCtrl', coordinator, cb),
+                (cb) => device.bind('hvacThermostat', coordinator, cb),
+                (cb) => device.report('hvacThermostat', 'localTemp', 300, 3600, 0, cb),
+                (cb) => device.report('hvacThermostat', 'pIHeatingDemand', 1, 0, 1, cb),
+                (cb) => device.report('genPowerCfg', 'batteryPercentageRemaining', 300, 3600, 0, cb),
+            ];
+
+            execute(device, actions, callback);
+        },
+    },
 ];
 
 module.exports = devices.map((device) =>

--- a/devices.js
+++ b/devices.js
@@ -2282,22 +2282,24 @@ const devices = [
         description: 'Wireless heater thermostat',
         supports: 'temperature, heating system control',
         fromZigbee: [
-            fz.ignore_basic_change, fz.thermostat_att_report, fz.thermostat_dev_change,
-            fz.eurotronic_thermostat_att_report, fz.eurotronic_thermostat_dev_change,
-            fz.hue_battery,
+            fz.thermostat_att_report, fz.eurotronic_thermostat_att_report,
+            fz.ignore_thermostat_change, fz.hue_battery, fz.ignore_power_change,
         ],
         toZigbee: [
             tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,
             tz.thermostat_local_temperature_calibration, tz.thermostat_system_mode,
-            tz.spzb0001_system_mode, tz.spzb0001_16386,
+            tz.eurotronic_system_mode, tz.eurotronic_16386, tz.thermostat_setpoint_raise_lower,
+            tz.thermostat_control_sequence_of_operation, tz.thermostat_remote_sensing,
         ],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);
             const actions = [
-                (cb) => device.bind('genBasic', coordinator, cb),
                 (cb) => device.bind('genPowerCfg', coordinator, cb),
                 (cb) => device.bind('hvacThermostat', coordinator, cb),
                 (cb) => device.report('hvacThermostat', 'localTemp', 1, 1200, 25, cb),
+                (cb) => device.foundation('hvacThermostat', 'configReport', [{
+                    direction: 0, attrId: 16387, dataType: 41, minRepIntval: 0,
+                    maxRepIntval: 600, repChange: 25}], {manufSpec: 1, manufCode: 4151}, cb),
             ];
 
             execute(device, actions, callback);

--- a/devices.js
+++ b/devices.js
@@ -2277,9 +2277,9 @@ const devices = [
     // Eurotronic
     {
         zigbeeModel: ['SPZB0001'],
-        model: 'Spirit Zigbee (SPZB0001)',
+        model: 'SPZB0001',
         vendor: 'Eurotronic',
-        description: 'Wireless heater thermostat',
+        description: 'Spirit Zigbee wireless heater thermostat',
         supports: 'temperature, heating system control',
         fromZigbee: [
             fz.thermostat_att_report, fz.eurotronic_thermostat_att_report,

--- a/devices.js
+++ b/devices.js
@@ -2322,7 +2322,7 @@ const devices = [
             execute(device, actions, callback);
         },
     },
-  
+
     // Livolo
     {
         zigbeeModel: ['TI0001          '],


### PR DESCRIPTION
Basic functions (set temperature and read/notifications of important data working.
 
Whats working:
- get heating setpoint (through occupied/unoccupied heating setpoint, push)
- get temperature selected at device (current_heating_setpoint, push)
- get battery percentage (push)
- get heating demand/valve opening (pi_heating_demand, push)
- get measured temperature at device (local_temperature, push)
- set desired temperature (through writing occupied/unoccupied heating setpoint)

Whats unclear/unsupported/not working
- systemMode off/heat -> device doesnt seem to react to write access 
- schedules (not tried)
- occupancy: read only, how to set it from outside?
- usage of occupied/unoccupied heating setpoints due to missing occupancy setting
- direct setting of current_heating_setpoint not possible (set occupied_heating_setpoint to achive that)
- there are two custom attributes (16386/16392) in the hvacThermostat cid occasionally reported, unclear what the values (1/0) mean.

