### PR TITLE
add report handling to generic light_onoff_brightness

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -16,17 +16,17 @@ const generic = {
     },
     light_onoff_brightness_colortemp: {
         supports: 'on/off, brightness, color temperature',
-        fromZigbee: [fz.light_brightness, fz.light_color_colortemp, fz.light_state],
+        fromZigbee: [fz.light_brightness, fz.light_color_colortemp, fz.light_state, fz.generic_state, fz.light_brightness_report],
         toZigbee: [tz.on_off, tz.light_brightness, tz.light_colortemp, tz.ignore_transition, tz.light_alert],
     },
     light_onoff_brightness_colorxy: {
         supports: 'on/off, brightness, color xy',
-        fromZigbee: [fz.light_brightness, fz.light_color_colortemp, fz.light_state],
+        fromZigbee: [fz.light_brightness, fz.light_color_colortemp, fz.light_state, fz.generic_state, fz.light_brightness_report],
         toZigbee: [tz.on_off, tz.light_brightness, tz.light_color, tz.ignore_transition, tz.light_alert],
     },
     light_onoff_brightness_colortemp_colorxy: {
         supports: 'on/off, brightness, color temperature, color xy',
-        fromZigbee: [fz.light_brightness, fz.light_color_colortemp, fz.light_state],
+        fromZigbee: [fz.light_brightness, fz.light_color_colortemp, fz.light_state, fz.generic_state, fz.light_brightness_report],
         toZigbee: [
             tz.on_off, tz.light_brightness, tz.light_colortemp, tz.light_color, tz.ignore_transition,
             tz.light_alert,

--- a/devices.js
+++ b/devices.js
@@ -16,17 +16,26 @@ const generic = {
     },
     light_onoff_brightness_colortemp: {
         supports: 'on/off, brightness, color temperature',
-        fromZigbee: [fz.light_brightness, fz.light_color_colortemp, fz.light_state, fz.generic_state, fz.light_brightness_report],
+        fromZigbee: [
+            fz.light_brightness, fz.light_color_colortemp, fz.light_state, fz.generic_state,
+            fz.light_brightness_report,
+        ],
         toZigbee: [tz.on_off, tz.light_brightness, tz.light_colortemp, tz.ignore_transition, tz.light_alert],
     },
     light_onoff_brightness_colorxy: {
         supports: 'on/off, brightness, color xy',
-        fromZigbee: [fz.light_brightness, fz.light_color_colortemp, fz.light_state, fz.generic_state, fz.light_brightness_report],
+        fromZigbee: [
+            fz.light_brightness, fz.light_color_colortemp, fz.light_state, fz.generic_state,
+            fz.light_brightness_report,
+        ],
         toZigbee: [tz.on_off, tz.light_brightness, tz.light_color, tz.ignore_transition, tz.light_alert],
     },
     light_onoff_brightness_colortemp_colorxy: {
         supports: 'on/off, brightness, color temperature, color xy',
-        fromZigbee: [fz.light_brightness, fz.light_color_colortemp, fz.light_state, fz.generic_state, fz.light_brightness_report],
+        fromZigbee: [
+            fz.light_brightness, fz.light_color_colortemp, fz.light_state, fz.generic_state, 
+            fz.light_brightness_report,
+        ],
         toZigbee: [
             tz.on_off, tz.light_brightness, tz.light_colortemp, tz.light_color, tz.ignore_transition,
             tz.light_alert,

--- a/devices.js
+++ b/devices.js
@@ -33,7 +33,7 @@ const generic = {
     light_onoff_brightness_colortemp_colorxy: {
         supports: 'on/off, brightness, color temperature, color xy',
         fromZigbee: [
-            fz.light_brightness, fz.light_color_colortemp, fz.light_state, fz.generic_state, 
+            fz.light_brightness, fz.light_color_colortemp, fz.light_state, fz.generic_state,
             fz.light_brightness_report,
         ],
         toZigbee: [

--- a/devices.js
+++ b/devices.js
@@ -11,7 +11,7 @@ const repInterval = {
 const generic = {
     light_onoff_brightness: {
         supports: 'on/off, brightness',
-        fromZigbee: [fz.light_brightness, fz.light_state],
+        fromZigbee: [fz.light_brightness, fz.light_state, fz.generic_state, fz.light_brightness_report],
         toZigbee: [tz.on_off, tz.light_brightness, tz.ignore_transition, tz.light_alert],
     },
     light_onoff_brightness_colortemp: {


### PR DESCRIPTION
Report handling only added to generic onoff_brightness device. Maybe all generic lights should be able to handle reports. If the light bulb doesn't send the reports, it doesn't matter. If it does, reports should be properly handled.