### PR TITLE
Add combined toZigbee color and colortemp converter.

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -310,6 +310,41 @@ const converters = {
             }
         },
     },
+    // This convertor is a combination of light_color and light_colortemp and
+    // can be used instead of the two individual convertors. When used to set,
+    // it actually calls out to light_color or light_colortemp to get the
+    // return value. When used to get, it gets both color and colorTemp in
+    // one call.
+    // The reason for the existence of this somewhat peculiar converter is
+    // that some lights don't report their state when changed. To fix this,
+    // we query the state after we set it. We want to query color and colorTemp
+    // both when setting either, because both change when setting one. This
+    // converter is used to do just that.
+    light_color_colortemp: {
+        key: ['color', 'color_temp', 'color_temp_percent'],
+        convert: (key, value, message, type, postfix) => {
+            const cid = 'lightingColorCtrl';
+            if (type === 'set') {
+                if (key == 'color') {
+                    return converters.light_color.convert(key, value, message, type, postfix);
+                } else if (key == 'color_temp' || key == 'color_temp_percent') {
+                    return converters.light_colortemp.convert(key, value, message, type, postfix);
+                }
+            } else if (type == 'get') {
+                return {
+                    cid: cid,
+                    cmd: 'read',
+                    cmdType: 'foundation',
+                    zclData: [
+                        {attrId: zclId.attr(cid, 'currentX').value},
+                        {attrId: zclId.attr(cid, 'currentY').value},
+                        {attrId: zclId.attr(cid, 'colorTemperature').value},
+                    ],
+                    cfg: cfg.default,
+                };
+            }
+        },
+    },
     light_alert: {
         key: ['alert', 'flash'],
         convert: (key, value, message, type, postfix) => {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -310,8 +310,8 @@ const converters = {
             }
         },
     },
-    // This convertor is a combination of light_color and light_colortemp and
-    // can be used instead of the two individual convertors. When used to set,
+    // This converter is a combination of light_color and light_colortemp and
+    // can be used instead of the two individual converters. When used to set,
     // it actually calls out to light_color or light_colortemp to get the
     // return value. When used to get, it gets both color and colorTemp in
     // one call.

--- a/devices.js
+++ b/devices.js
@@ -2249,7 +2249,7 @@ const devices = [
         zigbeeModel: ['ZLL-ExtendedColo'],
         model: '81809',
         vendor: 'AduroSmart',
-        description: 'ERIA Colors and White Shades Smart Light Bulb A19',
+        description: 'ERIA colors and white shades smart light bulb A19',
         extend: generic.light_onoff_brightness_colortemp_colorxy,
         ep: (device) => {
             return {

--- a/devices.js
+++ b/devices.js
@@ -37,7 +37,7 @@ const generic = {
             fz.brightness_report, fz.color_colortemp_report,
         ],
         toZigbee: [
-            tz.on_off, tz.light_brightness, tz.light_colortemp, tz.light_color, tz.ignore_transition,
+            tz.on_off, tz.light_brightness, tz.light_color_colortemp, tz.ignore_transition,
             tz.light_alert,
         ],
     },

--- a/devices.js
+++ b/devices.js
@@ -2243,6 +2243,20 @@ const devices = [
             execute(device, actions, callback);
         },
     },
+
+    // AduroSmart
+    {
+        zigbeeModel: ['ZLL-ExtendedColo'],
+        model: '81809',
+        vendor: 'AduroSmart',
+        description: 'ERIA Colors and White Shades Smart Light Bulb A19',
+        extend: generic.light_onoff_brightness_colortemp_colorxy,
+        ep: (device) => {
+            return {
+                '': 2,
+            };
+        },
+    },
 ];
 
 module.exports = devices.map((device) =>


### PR DESCRIPTION
This convertor is a combination of light_color and light_colortemp and can be used instead of the two individual convertors. When used to set, it actually calls out to light_color or light_colortemp to get the return value. When used to get, it gets both color and colorTemp in one call.
The reason for the existence of this somewhat peculiar converter is that some lights don't report their state when changed. To fix this, we query the state after we set it. We want to query color and colorTemp both when setting either, because both change when setting one. This converter is used to do just that.
    
We're using this convertor by default now in generic.light_onoff_brightness_colortemp_colorxy because it can't hurt.

Related to discussion in https://github.com/Koenkk/zigbee2mqtt/issues/939