### PR TITLE
Add support for AduroSmart ERIA Smart Wireless Dimming Switch

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1594,6 +1594,28 @@ const converters = {
             return payload;
         },
     },
+    eria_81825_on: {
+        cid: 'genOnOff',
+        type: 'cmdOn',
+        convert: (model, msg, publish, options) => {
+            return {action: 'on'};
+        },
+    },
+    eria_81825_off: {
+        cid: 'genOnOff',
+        type: 'cmdOff',
+        convert: (model, msg, publish, options) => {
+            return {action: 'off'};
+        },
+    },
+    eria_81825_updown: {
+        cid: 'genLevelCtrl',
+        type: 'cmdStep',
+        convert: (model, msg, publish, options) => {
+            const direction = msg.data.data.stepmode === 0 ? 'up' : 'down';
+            return {action: `${direction}`};
+        },
+    },
 
     // Ignore converters (these message dont need parsing).
     ignore_doorlock_change: {

--- a/devices.js
+++ b/devices.js
@@ -2316,6 +2316,7 @@ const devices = [
         model: '81825',
         vendor: 'AduroSmart',
         description: 'ERIA smart wireless dimming switch',
+        supports: 'on, off, up, down',
         fromZigbee: [fz.eria_81825_on, fz.eria_81825_off, fz.eria_81825_updown],
         toZigbee: [],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {

--- a/devices.js
+++ b/devices.js
@@ -2311,6 +2311,23 @@ const devices = [
             };
         },
     },
+    {
+        zigbeeModel: ['Adurolight_NCC'],
+        model: '81825',
+        vendor: 'AduroSmart',
+        description: 'ERIA smart wireless dimming switch',
+        fromZigbee: [fz.eria_81825_on, fz.eria_81825_off, fz.eria_81825_updown],
+        toZigbee: [],
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const device = shepherd.find(ieeeAddr, 1);
+            const actions = [
+                (cb) => device.bind('genOnOff', coordinator, cb),
+                (cb) => device.bind('genLevelCtrl', coordinator, cb),
+            ];
+
+            execute(device, actions, callback);
+        },
+    },
 
     // Eurotronic
     {


### PR DESCRIPTION
Switch returns event on button release. Hold not supported.
Implemented as action sensor, returning actions on, off, up, down.

Proprietary cluster PRs in zcl-id and zcl-packet need to be merged
first.

URL: https://adurosmart.com/products/adurosmart-eria-smart-dimming-switch-hub-required
Image: https://static1.squarespace.com/static/5b73cad4aa49a1238f3c98ab/5b74eb9fb8a045d2f8b7d562/5b764e90562fa74310b76949/1534480018645/81825-Dimmng-switch-3.jpg?format=2500w

Related issue: https://github.com/Koenkk/zigbee2mqtt/issues/939

Home Assistant support PR will follow (it's just a sensor_action).