### PR TITLE
Update toZigbee.js

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -367,10 +367,11 @@ const converters = {
                     cmd: 'write',
                     cmdType: 'foundation',
                     zclData: [{
-                        attrId: attrId,
+                        attrId: zclId.attr(cid, attrId).value,
                         dataType: zclId.attrType(cid, attrId).value,
                         attrData: Math.round(value * 10),
                     }],
+                    cfg: cfg.default,
                 };
             } else if (type === 'get') {
                 return {


### PR DESCRIPTION
Bugfix: Eurotronic zigbee thermostat support: localTemperatureCalibration was not written correctly to the device.