### PR TITLE
More custom attributes for Eurotronic SPZB0001

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1444,28 +1444,10 @@ const converters = {
                     precisionRound(msg.data.data[16387], 2) / 100;
             }
             if (typeof msg.data.data[16392] == 'number') {
-                result.spzb_system_mode = msg.data.data[16392];
+                result.eurotronic_system_mode = msg.data.data[16392];
             }
             if (typeof msg.data.data[16386] == 'number') {
-                result.spzb_16386 = msg.data.data[16386];
-            }
-            return result;
-        },
-    },
-    eurotronic_thermostat_dev_change: {
-        cid: 'hvacThermostat',
-        type: 'devChange',
-        convert: (model, msg, publish, options) => {
-            const result = {};
-            if (typeof msg.data.data[16387] == 'number') {
-                result.current_heating_setpoint =
-                    precisionRound(msg.data.data[16387], 2) / 100;
-            }
-            if (typeof msg.data.data[16392] == 'number') {
-                result.spzb_system_mode = msg.data.data[16392];
-            }
-            if (typeof msg.data.data[16386] == 'number') {
-                result.spzb_16386 = msg.data.data[16386];
+                result.eurotronic_16386 = msg.data.data[16386];
             }
             return result;
         },
@@ -1647,6 +1629,11 @@ const converters = {
     ignore_closuresWindowCovering_report: {
         cid: 'closuresWindowCovering',
         type: 'attReport',
+        convert: (model, msg, publish, options) => null,
+    },
+    ignore_thermostat_change: {
+        cid: 'hvacThermostat',
+        type: 'devChange',
         convert: (model, msg, publish, options) => null,
     },
 };

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1368,6 +1368,9 @@ const converters = {
             if (typeof state == 'number' && common.thermostatRunningStates.hasOwnProperty(state)) {
                 result.running_state = common.thermostatRunningStates[state];
             }
+            if (typeof msg.data.data['pIHeatingDemand'] == 'number') {
+                result.pi_heating_demand = msg.data.data['pIHeatingDemand'];
+            }
             return result;
         },
     },
@@ -1425,6 +1428,9 @@ const converters = {
             if (typeof state == 'number' && common.thermostatRunningStates.hasOwnProperty(state)) {
                 result.running_state = common.thermostatRunningStates[state];
             }
+            if (typeof msg.data.data['pIHeatingDemand'] == 'number') {
+                result.pi_heating_demand = msg.data.data['pIHeatingDemand'];
+            }
             return result;
         },
     },
@@ -1433,30 +1439,15 @@ const converters = {
         type: 'attReport',
         convert: (model, msg, publish, options) => {
             const result = {};
-            if (typeof msg.data.data['localTemp'] == 'number') {
-                result.local_temperature = precisionRound(msg.data.data['localTemp'], 2) / 100;
-            }
-            if (typeof msg.data.data['localTemperatureCalibration'] == 'number') {
-                result.local_temperature_calibration =
-                    precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10;
-            }
-            if (typeof msg.data.data['occupiedHeatingSetpoint'] == 'number') {
-                result.occupied_heating_setpoint =
-                    precisionRound(msg.data.data['occupiedHeatingSetpoint'], 2) / 100;
-            }
-            if (typeof msg.data.data['unoccupiedHeatingSetpoint'] == 'number') {
-                result.unoccupied_heating_setpoint =
-                    precisionRound(msg.data.data['unoccupiedHeatingSetpoint'], 2) / 100;
-            }
-            if (typeof msg.data.data['setpointChangeAmount'] == 'number') {
-                result.setpoint_change_amount = msg.data.data['setpointChangeAmount'] / 100;
-            }
-            if (typeof msg.data.data['pIHeatingDemand'] == 'number') {
-                result.pi_heating_demand = msg.data.data['pIHeatingDemand'];
-            }
             if (typeof msg.data.data[16387] == 'number') {
                 result.current_heating_setpoint =
                     precisionRound(msg.data.data[16387], 2) / 100;
+            }
+            if (typeof msg.data.data[16392] == 'number') {
+                result.spzb_system_mode = msg.data.data[16392];
+            }
+            if (typeof msg.data.data[16386] == 'number') {
+                result.spzb_16386 = msg.data.data[16386];
             }
             return result;
         },
@@ -1466,38 +1457,15 @@ const converters = {
         type: 'devChange',
         convert: (model, msg, publish, options) => {
             const result = {};
-            if (typeof msg.data.data['localTemp'] == 'number') {
-                result.local_temperature = precisionRound(msg.data.data['localTemp'], 2) / 100;
-            }
-            if (typeof msg.data.data['localTemperatureCalibration'] == 'number') {
-                result.local_temperature_calibration =
-                    precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10;
-            }
-            if (typeof msg.data.data['occupiedHeatingSetpoint'] == 'number') {
-                result.occupied_heating_setpoint =
-                    precisionRound(msg.data.data['occupiedHeatingSetpoint'], 2) / 100;
-            }
-            if (typeof msg.data.data['unoccupiedHeatingSetpoint'] == 'number') {
-                result.unoccupied_heating_setpoint =
-                    precisionRound(msg.data.data['unoccupiedHeatingSetpoint'], 2) / 100;
-            }
-            if (typeof msg.data.data['pIHeatingDemand'] == 'number') {
-                result.pi_heating_demand = msg.data.data['pIHeatingDemand'];
-            }
             if (typeof msg.data.data[16387] == 'number') {
                 result.current_heating_setpoint =
                     precisionRound(msg.data.data[16387], 2) / 100;
             }
-            return result;
-        },
-    },
-    eurotronic_battery_dev_change: {
-        cid: 'genPowerCfg',
-        type: 'devChange',
-        convert: (model, msg, publish, options) => {
-            const result = {};
-            if (typeof msg.data.data['batteryPercentageRemaining'] == 'number') {
-                return {battery: precisionRound(msg.data.data['batteryPercentageRemaining'], 2) / 2};
+            if (typeof msg.data.data[16392] == 'number') {
+                result.spzb_system_mode = msg.data.data[16392];
+            }
+            if (typeof msg.data.data[16386] == 'number') {
+                result.spzb_16386 = msg.data.data[16386];
             }
             return result;
         },

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1496,20 +1496,26 @@ const converters = {
             return result;
         },
     },
-    eurotronic_thermostat_att_report: {
+    eurotronic_thermostat_dev_change: {
         cid: 'hvacThermostat',
-        type: 'attReport',
+        type: 'devChange',
         convert: (model, msg, publish, options) => {
             const result = {};
-            if (typeof msg.data.data[16387] == 'number') {
+            if (typeof msg.data.data[0x4003] == 'number') {
                 result.current_heating_setpoint =
-                    precisionRound(msg.data.data[16387], 2) / 100;
+                    precisionRound(msg.data.data[0x4003], 2) / 100;
             }
-            if (typeof msg.data.data[16392] == 'number') {
-                result.eurotronic_system_mode = msg.data.data[16392];
+            if (typeof msg.data.data[0x4008] == 'number') {
+                result.eurotronic_system_mode = msg.data.data[0x4008];
             }
-            if (typeof msg.data.data[16386] == 'number') {
-                result.eurotronic_16386 = msg.data.data[16386];
+            if (typeof msg.data.data[0x4002] == 'number') {
+                result.eurotronic_error_status = msg.data.data[0x4002];
+            }
+            if (typeof msg.data.data[0x4000] == 'number') {
+                result.eurotronic_trv_mode = msg.data.data[0x4000];
+            }
+            if (typeof msg.data.data[0x4001] == 'number') {
+                result.eurotronic_valve_position = msg.data.data[0x4001];
             }
             return result;
         },
@@ -1737,6 +1743,11 @@ const converters = {
     ignore_thermostat_change: {
         cid: 'hvacThermostat',
         type: 'devChange',
+        convert: (model, msg, publish, options) => null,
+    },
+    ignore_thermostat_report: {
+        cid: 'hvacThermostat',
+        type: 'attReport',
         convert: (model, msg, publish, options) => null,
     },
     ignore_genGroups_devChange: {

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1428,6 +1428,80 @@ const converters = {
             return result;
         },
     },
+    eurotronic_thermostat_att_report: {
+        cid: 'hvacThermostat',
+        type: 'attReport',
+        convert: (model, msg, publish, options) => {
+            const result = {};
+            if (typeof msg.data.data['localTemp'] == 'number') {
+                result.local_temperature = precisionRound(msg.data.data['localTemp'], 2) / 100;
+            }
+            if (typeof msg.data.data['localTemperatureCalibration'] == 'number') {
+                result.local_temperature_calibration =
+                    precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10;
+            }
+            if (typeof msg.data.data['occupiedHeatingSetpoint'] == 'number') {
+                result.occupied_heating_setpoint =
+                    precisionRound(msg.data.data['occupiedHeatingSetpoint'], 2) / 100;
+            }
+            if (typeof msg.data.data['unoccupiedHeatingSetpoint'] == 'number') {
+                result.unoccupied_heating_setpoint =
+                    precisionRound(msg.data.data['unoccupiedHeatingSetpoint'], 2) / 100;
+            }
+            if (typeof msg.data.data['setpointChangeAmount'] == 'number') {
+                result.setpoint_change_amount = msg.data.data['setpointChangeAmount'] / 100;
+            }
+            if (typeof msg.data.data['pIHeatingDemand'] == 'number') {
+                result.pi_heating_demand = msg.data.data['pIHeatingDemand'];
+            }
+            if (typeof msg.data.data[16387] == 'number') {
+                result.current_heating_setpoint =
+                    precisionRound(msg.data.data[16387], 2) / 100;
+            }
+            return result;
+        },
+    },
+    eurotronic_thermostat_dev_change: {
+        cid: 'hvacThermostat',
+        type: 'devChange',
+        convert: (model, msg, publish, options) => {
+            const result = {};
+            if (typeof msg.data.data['localTemp'] == 'number') {
+                result.local_temperature = precisionRound(msg.data.data['localTemp'], 2) / 100;
+            }
+            if (typeof msg.data.data['localTemperatureCalibration'] == 'number') {
+                result.local_temperature_calibration =
+                    precisionRound(msg.data.data['localTemperatureCalibration'], 2) / 10;
+            }
+            if (typeof msg.data.data['occupiedHeatingSetpoint'] == 'number') {
+                result.occupied_heating_setpoint =
+                    precisionRound(msg.data.data['occupiedHeatingSetpoint'], 2) / 100;
+            }
+            if (typeof msg.data.data['unoccupiedHeatingSetpoint'] == 'number') {
+                result.unoccupied_heating_setpoint =
+                    precisionRound(msg.data.data['unoccupiedHeatingSetpoint'], 2) / 100;
+            }
+            if (typeof msg.data.data['pIHeatingDemand'] == 'number') {
+                result.pi_heating_demand = msg.data.data['pIHeatingDemand'];
+            }
+            if (typeof msg.data.data[16387] == 'number') {
+                result.current_heating_setpoint =
+                    precisionRound(msg.data.data[16387], 2) / 100;
+            }
+            return result;
+        },
+    },
+    eurotronic_battery_dev_change: {
+        cid: 'genPowerCfg',
+        type: 'devChange',
+        convert: (model, msg, publish, options) => {
+            const result = {};
+            if (typeof msg.data.data['batteryPercentageRemaining'] == 'number') {
+                return {battery: precisionRound(msg.data.data['batteryPercentageRemaining'], 2) / 2};
+            }
+            return result;
+        },
+    },
     E1524_toggle: {
         cid: 'genOnOff',
         type: 'cmdToggle',

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -938,7 +938,7 @@ const converters = {
                 return {
                     cid: cid,
                     cmd: 'read',
-                    cmdType: 'foundation',              
+                    cmdType: 'foundation',
                     zclData: [{attrId: attrId}],
                     cfg: cfg.eurotronic,
                 };

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -886,8 +886,8 @@ const converters = {
             };
         },
     },
-    spzb0001_system_mode: {
-        key: 'spzb_system_mode',
+    eurotronic_system_mode: {
+        key: 'eurotronic_system_mode',
         convert: (key, value, message, type) => {
             const cid = 'hvacThermostat';
             const attrId = 16392;
@@ -917,8 +917,8 @@ const converters = {
             }
         },
     },
-    spzb0001_16386: {
-        key: 'spzb_16386',
+    eurotronic_16386: {
+        key: 'eurotronic_16386',
         convert: (key, value, message, type) => {
             const cid = 'hvacThermostat';
             const attrId = 16386;
@@ -929,7 +929,7 @@ const converters = {
                     cmdType: 'foundation',
                     zclData: [{
                         attrId: attrId,
-                        dataType: 0x22,
+                        dataType: 0x20,
                         attrData: value,
                     }],
                     cfg: cfg.eurotronic,

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -14,6 +14,10 @@ const cfg = {
         disDefaultRsp: 1,
         manufCode: 0x115F,
     },
+    eurotronic: { 
+        manufSpec: 1,
+        manufCode: 4151, 
+    },
 };
 
 const converters = {
@@ -880,6 +884,65 @@ const converters = {
                 }],
                 cfg: cfg.default,
             };
+        },
+    },
+    spzb0001_system_mode: {
+        key: 'spzb_system_mode',
+        convert: (key, value, message, type) => {
+            const cid = 'hvacThermostat';
+            const attrId = 16392;
+            if (type === 'set') {
+                return {
+                    cid: cid,
+                    cmd: 'write',
+                    cmdType: 'foundation',
+                    zclData: [{
+                        // Bit 0 = ? (default 1)
+                        // Bit 2 = Boost
+                        // Bit 7 = Child protection
+                        attrId: attrId,
+                        dataType: 0x22,
+                        attrData: value,
+                    }],
+                    cfg: cfg.eurotronic,
+                };
+            } else if (type === 'get') {
+                return {
+                    cid: cid,
+                    cmd: 'read',
+                    cmdType: 'foundation',
+                    zclData: [{attrId: attrId}],
+                    cfg: cfg.eurotronic,
+                };
+            }
+        },
+    },
+    spzb0001_16386: {
+        key: 'spzb_16386',
+        convert: (key, value, message, type) => {
+            const cid = 'hvacThermostat';
+            const attrId = 16386;
+            if (type === 'set') {
+                return {
+                    cid: cid,
+                    cmd: 'write',
+                    cmdType: 'foundation',
+                    zclData: [{
+                        attrId: attrId,
+                        dataType: 0x22,
+                        attrData: value,
+                    }],
+                    cfg: cfg.eurotronic,
+                };
+            } else if (type === 'get') {
+                return {
+                    cid: cid,
+                    cmd: 'read',
+                    cmdType: 'foundation',
+                    zclData: [{attrId: attrId}],
+                    cfg: cfg.eurotronic,
+                };
+            }
         },
     },
 

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -888,7 +888,7 @@ const converters = {
     },
     eurotronic_system_mode: {
         key: 'eurotronic_system_mode',
-        convert: (key, value, message, type) => {
+        convert: (key, value, message, type, postfix) => {
             const cid = 'hvacThermostat';
             const attrId = 16392;
             if (type === 'set') {
@@ -919,7 +919,7 @@ const converters = {
     },
     eurotronic_16386: {
         key: 'eurotronic_16386',
-        convert: (key, value, message, type) => {
+        convert: (key, value, message, type, postfix) => {
             const cid = 'hvacThermostat';
             const attrId = 16386;
             if (type === 'set') {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -926,7 +926,7 @@ const converters = {
         key: 'eurotronic_system_mode',
         convert: (key, value, message, type, postfix) => {
             const cid = 'hvacThermostat';
-            const attrId = 16392;
+            const attrId = 0x4008;
             if (type === 'set') {
                 return {
                     cid: cid,
@@ -935,6 +935,7 @@ const converters = {
                     zclData: [{
                         // Bit 0 = ? (default 1)
                         // Bit 2 = Boost
+                        // Bit 4 = Window open
                         // Bit 7 = Child protection
                         attrId: attrId,
                         dataType: 0x22,
@@ -953,11 +954,55 @@ const converters = {
             }
         },
     },
-    eurotronic_16386: {
-        key: 'eurotronic_16386',
+    eurotronic_error_status: {
+        key: 'eurotronic_error_status',
         convert: (key, value, message, type, postfix) => {
             const cid = 'hvacThermostat';
-            const attrId = 16386;
+            const attrId = 0x4002;
+            if (type === 'get') {
+                return {
+                    cid: cid,
+                    cmd: 'read',
+                    cmdType: 'foundation',
+                    zclData: [{attrId: attrId}],
+                    cfg: cfg.eurotronic,
+                };
+            }
+        },
+    },
+    eurotronic_current_heating_setpoint: {
+        key: 'current_heating_setpoint',
+        convert: (key, value, message, type, postfix) => {
+            const cid = 'hvacThermostat';
+            const attrId = 0x4003;
+            if (type === 'set') {
+                return {
+                    cid: cid,
+                    cmd: 'write',
+                    cmdType: 'foundation',
+                    zclData: [{
+                        attrId: attrId,
+                        dataType: 0x29,
+                        attrData: (Math.round((value * 2).toFixed(1))/2).toFixed(1) * 100,
+                    }],
+                    cfg: cfg.eurotronic,
+                };
+            } else if (type === 'get') {
+                return {
+                    cid: cid,
+                    cmd: 'read',
+                    cmdType: 'foundation',
+                    zclData: [{attrId: attrId}],
+                    cfg: cfg.eurotronic,
+                };
+            }
+        },
+    },
+    eurotronic_valve_position: {
+        key: 'eurotronic_valve_position',
+        convert: (key, value, message, type, postfix) => {
+            const cid = 'hvacThermostat';
+            const attrId = 0x4001;
             if (type === 'set') {
                 return {
                     cid: cid,
@@ -966,6 +1011,34 @@ const converters = {
                     zclData: [{
                         attrId: attrId,
                         dataType: 0x20,
+                        attrData: value,
+                    }],
+                    cfg: cfg.eurotronic,
+                };
+            } else if (type === 'get') {
+                return {
+                    cid: cid,
+                    cmd: 'read',
+                    cmdType: 'foundation',
+                    zclData: [{attrId: attrId}],
+                    cfg: cfg.eurotronic,
+                };
+            }
+        },
+    },
+    eurotronic_trv_mode: {
+        key: 'eurotronic_trv_mode',
+        convert: (key, value, message, type, postfix) => {
+            const cid = 'hvacThermostat';
+            const attrId = 0x4000;
+            if (type === 'set') {
+                return {
+                    cid: cid,
+                    cmd: 'write',
+                    cmdType: 'foundation',
+                    zclData: [{
+                        attrId: attrId,
+                        dataType: 0x30,
                         attrData: value,
                     }],
                     cfg: cfg.eurotronic,

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -14,9 +14,9 @@ const cfg = {
         disDefaultRsp: 1,
         manufCode: 0x115F,
     },
-    eurotronic: { 
+    eurotronic: {
         manufSpec: 1,
-        manufCode: 4151, 
+        manufCode: 4151,
     },
 };
 

--- a/devices.js
+++ b/devices.js
@@ -2283,8 +2283,8 @@ const devices = [
         supports: 'temperature, heating system control',
         fromZigbee: [
             fz.ignore_basic_change, fz.thermostat_att_report, fz.thermostat_dev_change,
-            fz.eurotronic_thermostat_att_report, fz.eurotronic_thermostat_dev_change, 
-            fz.hue_battery
+            fz.eurotronic_thermostat_att_report, fz.eurotronic_thermostat_dev_change,
+            fz.hue_battery,
         ],
         toZigbee: [
             tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,

--- a/devices.js
+++ b/devices.js
@@ -2282,25 +2282,22 @@ const devices = [
         description: 'Wireless heater thermostat',
         supports: 'temperature, heating system control',
         fromZigbee: [
-            fz.ignore_basic_change, fz.eurotronic_thermostat_att_report,
-            fz.eurotronic_thermostat_dev_change, fz.hue_battery, fz.eurotronic_battery_dev_change,
+            fz.ignore_basic_change, fz.thermostat_att_report, fz.thermostat_dev_change,
+            fz.eurotronic_thermostat_att_report, fz.eurotronic_thermostat_dev_change, 
+            fz.hue_battery
         ],
         toZigbee: [
             tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,
-            tz.thermostat_local_temperature_calibration,
+            tz.thermostat_local_temperature_calibration, tz.thermostat_system_mode,
+            tz.spzb0001_system_mode, tz.spzb0001_16386,
         ],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);
             const actions = [
                 (cb) => device.bind('genBasic', coordinator, cb),
                 (cb) => device.bind('genPowerCfg', coordinator, cb),
-                (cb) => device.bind('genIdentify', coordinator, cb),
-                (cb) => device.bind('genTime', coordinator, cb),
-                (cb) => device.bind('genPollCtrl', coordinator, cb),
                 (cb) => device.bind('hvacThermostat', coordinator, cb),
-                (cb) => device.report('hvacThermostat', 'localTemp', 300, 3600, 0, cb),
-                (cb) => device.report('hvacThermostat', 'pIHeatingDemand', 1, 0, 1, cb),
-                (cb) => device.report('genPowerCfg', 'batteryPercentageRemaining', 300, 3600, 0, cb),
+                (cb) => device.report('hvacThermostat', 'localTemp', 1, 1200, 25, cb),
             ];
 
             execute(device, actions, callback);

--- a/devices.js
+++ b/devices.js
@@ -2273,6 +2273,39 @@ const devices = [
             };
         },
     },
+
+    // Eurotronic
+    {
+        zigbeeModel: ['SPZB0001'],
+        model: 'Spirit Zigbee (SPZB0001)',
+        vendor: 'Eurotronic',
+        description: 'Wireless heater thermostat',
+        supports: 'temperature, heating system control',
+        fromZigbee: [
+            fz.ignore_basic_change, fz.eurotronic_thermostat_att_report,
+            fz.eurotronic_thermostat_dev_change, fz.hue_battery, fz.eurotronic_battery_dev_change,
+        ],
+        toZigbee: [
+            tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,
+            tz.thermostat_local_temperature_calibration,
+        ],
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const device = shepherd.find(ieeeAddr, 1);
+            const actions = [
+                (cb) => device.bind('genBasic', coordinator, cb),
+                (cb) => device.bind('genPowerCfg', coordinator, cb),
+                (cb) => device.bind('genIdentify', coordinator, cb),
+                (cb) => device.bind('genTime', coordinator, cb),
+                (cb) => device.bind('genPollCtrl', coordinator, cb),
+                (cb) => device.bind('hvacThermostat', coordinator, cb),
+                (cb) => device.report('hvacThermostat', 'localTemp', 300, 3600, 0, cb),
+                (cb) => device.report('hvacThermostat', 'pIHeatingDemand', 1, 0, 1, cb),
+                (cb) => device.report('genPowerCfg', 'batteryPercentageRemaining', 300, 3600, 0, cb),
+            ];
+
+            execute(device, actions, callback);
+        },
+    },
 ];
 
 module.exports = devices.map((device) =>

--- a/devices.js
+++ b/devices.js
@@ -2282,22 +2282,24 @@ const devices = [
         description: 'Wireless heater thermostat',
         supports: 'temperature, heating system control',
         fromZigbee: [
-            fz.ignore_basic_change, fz.thermostat_att_report, fz.thermostat_dev_change,
-            fz.eurotronic_thermostat_att_report, fz.eurotronic_thermostat_dev_change,
-            fz.hue_battery,
+            fz.thermostat_att_report, fz.eurotronic_thermostat_att_report,
+            fz.ignore_thermostat_change, fz.hue_battery, fz.ignore_power_change,
         ],
         toZigbee: [
             tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,
             tz.thermostat_local_temperature_calibration, tz.thermostat_system_mode,
-            tz.spzb0001_system_mode, tz.spzb0001_16386,
+            tz.eurotronic_system_mode, tz.eurotronic_16386, tz.thermostat_setpoint_raise_lower,
+            tz.thermostat_control_sequence_of_operation, tz.thermostat_remote_sensing,
         ],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);
             const actions = [
-                (cb) => device.bind('genBasic', coordinator, cb),
                 (cb) => device.bind('genPowerCfg', coordinator, cb),
                 (cb) => device.bind('hvacThermostat', coordinator, cb),
                 (cb) => device.report('hvacThermostat', 'localTemp', 1, 1200, 25, cb),
+                (cb) => device.foundation('hvacThermostat', 'configReport', [{
+                    direction: 0, attrId: 16387, dataType: 41, minRepIntval: 0,
+                    maxRepIntval: 600, repChange: 25}], {manufSpec: 1, manufCode: 4151}, cb),
             ];
 
             execute(device, actions, callback);

--- a/devices.js
+++ b/devices.js
@@ -2277,9 +2277,9 @@ const devices = [
     // Eurotronic
     {
         zigbeeModel: ['SPZB0001'],
-        model: 'Spirit Zigbee (SPZB0001)',
+        model: 'SPZB0001',
         vendor: 'Eurotronic',
-        description: 'Wireless heater thermostat',
+        description: 'Spirit Zigbee wireless heater thermostat',
         supports: 'temperature, heating system control',
         fromZigbee: [
             fz.thermostat_att_report, fz.eurotronic_thermostat_att_report,

--- a/devices.js
+++ b/devices.js
@@ -2356,14 +2356,16 @@ const devices = [
         description: 'Spirit Zigbee wireless heater thermostat',
         supports: 'temperature, heating system control',
         fromZigbee: [
-            fz.thermostat_att_report, fz.eurotronic_thermostat_att_report,
-            fz.ignore_thermostat_change, fz.hue_battery, fz.ignore_power_change,
+            fz.thermostat_dev_change,
+            fz.eurotronic_thermostat_dev_change,
+            fz.ignore_thermostat_report, fz.hue_battery, fz.ignore_power_change,
         ],
         toZigbee: [
             tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,
             tz.thermostat_local_temperature_calibration, tz.thermostat_system_mode,
-            tz.eurotronic_system_mode, tz.eurotronic_16386, tz.thermostat_setpoint_raise_lower,
+            tz.eurotronic_system_mode, tz.eurotronic_error_status, tz.thermostat_setpoint_raise_lower,
             tz.thermostat_control_sequence_of_operation, tz.thermostat_remote_sensing,
+            tz.eurotronic_current_heating_setpoint, tz.eurotronic_trv_mode, tz.eurotronic_valve_position,
         ],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);
@@ -2372,39 +2374,7 @@ const devices = [
                 (cb) => device.bind('hvacThermostat', coordinator, cb),
                 (cb) => device.report('hvacThermostat', 'localTemp', 1, 1200, 25, cb),
                 (cb) => device.foundation('hvacThermostat', 'configReport', [{
-                    direction: 0, attrId: 16387, dataType: 41, minRepIntval: 0,
-                    maxRepIntval: 600, repChange: 25}], {manufSpec: 1, manufCode: 4151}, cb),
-            ];
-
-            execute(device, actions, callback);
-        },
-    },
-
-    // Eurotronic
-    {
-        zigbeeModel: ['SPZB0001'],
-        model: 'SPZB0001',
-        vendor: 'Eurotronic',
-        description: 'Spirit Zigbee wireless heater thermostat',
-        supports: 'temperature, heating system control',
-        fromZigbee: [
-            fz.thermostat_att_report, fz.eurotronic_thermostat_att_report,
-            fz.ignore_thermostat_change, fz.hue_battery, fz.ignore_power_change,
-        ],
-        toZigbee: [
-            tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,
-            tz.thermostat_local_temperature_calibration, tz.thermostat_system_mode,
-            tz.eurotronic_system_mode, tz.eurotronic_16386, tz.thermostat_setpoint_raise_lower,
-            tz.thermostat_control_sequence_of_operation, tz.thermostat_remote_sensing,
-        ],
-        configure: (ieeeAddr, shepherd, coordinator, callback) => {
-            const device = shepherd.find(ieeeAddr, 1);
-            const actions = [
-                (cb) => device.bind('genPowerCfg', coordinator, cb),
-                (cb) => device.bind('hvacThermostat', coordinator, cb),
-                (cb) => device.report('hvacThermostat', 'localTemp', 1, 1200, 25, cb),
-                (cb) => device.foundation('hvacThermostat', 'configReport', [{
-                    direction: 0, attrId: 16387, dataType: 41, minRepIntval: 0,
+                    direction: 0, attrId: 0x4003, dataType: 41, minRepIntval: 0,
                     maxRepIntval: 600, repChange: 25}], {manufSpec: 1, manufCode: 4151}, cb),
             ];
 

--- a/devices.js
+++ b/devices.js
@@ -2322,7 +2322,7 @@ const devices = [
             execute(device, actions, callback);
         },
     },
-  
+
     // Livolo
     {
         zigbeeModel: ['TI0001          '],


### PR DESCRIPTION
Based on the last comments of @tfriedel in PR #254 the following attributes were added:

- eurotronic_trv_mode
- eurotronic_valve_position

Other changes:
- eurotronic_16386 is renamed to eurotronic_error_status 
- current_heating_setpoint is now writeable, no need to write to occupied/unoccupied_heating_setpoint 
- ignore attReport and listen to devChange because reading value requests tend to be answered just with a devChange message