### PR TITLE
Fixed HS1SA battery report

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2186,8 +2186,9 @@ const devices = [
                 (cb) => device.bind('ssIasZone', coordinator, cb),
                 (cb) => device.functional('ssIasZone', 'enrollRsp', {enrollrspcode: 0, zoneid: 23}, cb),
                 (cb) => device.bind('genPowerCfg', coordinator, cb),
-                (cb) => device.report('genPowerCfg', 'batteryPercentageRemaining', 0, 65535, 0, cb), // once per day
-                (cb) => device.report('genPowerCfg', 'batteryAlarmState', 1, 65535, 1, cb),
+                // Time is in seconds. 65535 means no report. 65534 is max value: 18 hours, 12 minutes 14 seconds.
+                (cb) => device.report('genPowerCfg', 'batteryPercentageRemaining', 0, 65534, 0, cb),
+                (cb) => device.report('genPowerCfg', 'batteryAlarmState', 1, 65534, 1, cb),
             ];
 
             execute(device, actions, callback, 1000);


### PR DESCRIPTION
Fixed battery report. It was set to 65535 which means "No report." Set to 65534 instead which gives a battery report every 18 h 12 m 14 s.