### PR TITLE
Decoupled mode for Xiaomi wired wall switches

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -802,6 +802,8 @@ const converters = {
         convert: (model, msg, publish, options) => {
             if (msg.data.data['61440']) {
                 return {state: msg.data.data['onOff'] === 1 ? 'ON' : 'OFF'};
+            } else {
+                return {click: 'single'};
             }
         },
     },
@@ -815,6 +817,10 @@ const converters = {
                 const payload = {};
                 payload[key] = msg.data.data['onOff'] === 1 ? 'ON' : 'OFF';
                 return payload;
+            } else {
+                const mapping = {4: 'left', 5: 'right', 6: 'both'};
+                const button = mapping[msg.endpoints[0].epId];
+                return {click: button};
             }
         },
     },

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -856,6 +856,52 @@ const converters = {
             }
         },
     },
+    xiaomi_decoupled_mode: {
+        key: ['decoupled_mode'],
+        convert: (key, value, message, type, postfix) => {
+            const cid = 'genBasic';
+            const lookupAttrId = {
+                'single': 0xFF22,
+                'left': 0xFF22,
+                'right': 0xFF23,
+            };
+            const lookupState = {
+                'decoupled': 0xFE,
+                'toggle_left': 0x12,
+                'toggle_right': 0x22,
+            };
+            let button;
+            if (value.hasOwnProperty('button')) {
+                button = value.button;
+            } else {
+                button = 'single';
+            }
+            if (type === 'set') {
+                return {
+                    cid: cid,
+                    cmd: 'write',
+                    cmdType: 'foundation',
+                    zclData: [{
+                        attrId: lookupAttrId[button],
+                        dataType: 0x20,
+                        attrData: lookupState[value.state],
+                    }],
+                    cfg: cfg.xiaomi,
+                };
+            } else if (type === 'get') {
+                return {
+                    cid: cid,
+                    cmd: 'read',
+                    cmdType: 'foundation',
+                    zclData: [{
+                        attrId: lookupAttrId[button],
+                        dataType: 0x20,
+                    }],
+                    cfg: cfg.xiaomi,
+                };
+            }
+        },
+    },
     STS_PRS_251_beep: {
         key: ['beep'],
         convert: (key, value, message, type, postfix) => {

--- a/devices.js
+++ b/devices.js
@@ -212,9 +212,9 @@ const devices = [
         fromZigbee: [
             fz.QBKG04LM_QBKG11LM_state, fz.ignore_onoff_change, fz.ignore_basic_change, fz.ignore_basic_report,
         ],
-        toZigbee: [tz.on_off],
+        toZigbee: [tz.on_off, tz.xiaomi_decoupled_mode],
         ep: (device) => {
-            return {'': 2};
+            return {'system': 1, 'default': 2};
         },
     },
     {
@@ -238,9 +238,9 @@ const devices = [
         fromZigbee: [
             fz.QBKG03LM_QBKG12LM_state, fz.QBKG03LM_buttons, fz.ignore_basic_change, fz.ignore_basic_report,
         ],
-        toZigbee: [tz.on_off],
+        toZigbee: [tz.on_off, tz.xiaomi_decoupled_mode],
         ep: (device) => {
-            return {'left': 2, 'right': 3};
+            return {'system': 1, 'left': 2, 'right': 3};
         },
     },
     {


### PR DESCRIPTION
Decoupled mode allows to turn wired switch into wireless button with separately control relay.
You can control relay remotely and assign some custom actions to buttons.
I also found that you can change which button controls which relay. For example, this can make right button to control left relay. Or both buttons to control the same relay.

Tested for QBKG03LM and QBKG04LM wired wall switches.

Usage:
`zigbee2mqtt/[DEVICE_ID]/system/set` to modify operation mode with payload:
```
{
  "decoupled_mode": {
    "button": "single"|"left"|"right",
    "state": "decoupled"|"toggle_left"|"toggle_right"
  }
}
```
`zigbee2mqtt/[DEVICE_ID]/system/get` to get current mode with payload:
```
{
  "decoupled_mode": {
    "button": "single"|"left"|"right"
  }
}
```