### PR TITLE
Fix problem with FB56+ZSW05HG1.2' (HGZB-01A) handler

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1854,6 +1854,24 @@ const devices = [
             }
         },
     },
+    
+    // Smart Home Pty
+    {
+        zigbeeModel: ['FB56-ZCW11HG1.2'],
+        model: 'HGZB-07A',
+        vendor: 'Smart Home Pty',
+        description: 'RGBW Downlight',
+        extend: generic.light_onoff_brightness_colortemp_colorxy,
+    },
+    {
+        zigbeeModel: ['FNB56-SKT1EHG1.2'],
+        model: 'HGZB-20-DE',
+        vendor: 'Smart Home Pty',
+        description: 'Power plug',
+        supports: 'on/off',
+        fromZigbee: [fz.state_change],
+        toZigbee: [tz.on_off],
+    },
 
     // SmartThings
     {

--- a/devices.js
+++ b/devices.js
@@ -1999,6 +1999,24 @@ const devices = [
             execute(device, actions, callback);
         },
     },
+    
+    // Smart Home Pty
+    {
+        zigbeeModel: ['FB56-ZCW11HG1.2'],
+        model: 'HGZB-07A',
+        vendor: 'Smart Home Pty',
+        description: 'RGBW Downlight',
+        extend: generic.light_onoff_brightness_colortemp_colorxy,
+    },
+    {
+        zigbeeModel: ['FNB56-SKT1EHG1.2'],
+        model: 'HGZB-20-DE',
+        vendor: 'Smart Home Pty',
+        description: 'Power plug',
+        supports: 'on/off',
+        fromZigbee: [fz.state_change],
+        toZigbee: [tz.on_off],
+    },
 
     // Paulmann
     {

--- a/devices.js
+++ b/devices.js
@@ -1668,11 +1668,11 @@ const devices = [
     // Nue
     {
         zigbeeModel: ['FB56+ZSW05HG1.2'],
-        model: 'FB56+ZSW05HG1.2',
+        model: 'HGZB-01A' ,
         vendor: 'Nue',
-        description: 'ZigBee one gang smart switch',
+        description: 'ZigBee one gang wall / in-wall smart switch',
         supports: 'on/off',
-        fromZigbee: [fz.state],
+        fromZigbee: [fz.state, fz.ignore_onoff_change],
         toZigbee: [tz.on_off],
     },
     {
@@ -1694,7 +1694,25 @@ const devices = [
         description: 'ZigBee smart light controller',
         extend: generic.light_onoff_brightness,
     },
-
+    
+    // Smart Home Pty
+    {
+        zigbeeModel: ['FB56-ZCW11HG1.2'],
+        model: 'HGZB-07A',
+        vendor: 'Smart Home Pty',
+        description: 'RGBW Downlight',
+        extend: generic.light_onoff_brightness_colortemp_colorxy,
+    },
+    {
+        zigbeeModel: ['FNB56-SKT1EHG1.2'],
+        model: 'HGZB-20-DE',
+        vendor: 'Smart Home Pty',
+        description: 'Power plug',
+        supports: 'on/off',
+        fromZigbee: [fz.state_change],
+        toZigbee: [tz.on_off],
+    },
+    
     // Gledopto
     {
         zigbeeModel: ['GLEDOPTO', 'GL-C-008', 'GL-C-007'],
@@ -2399,24 +2417,6 @@ const devices = [
         supports: 'on/off',
         fromZigbee: [],
         toZigbee: [],
-    },
-
-    // Smart Home Pty
-    {
-        zigbeeModel: ['FB56-ZCW11HG1.2'],
-        model: 'HGZB-07A',
-        vendor: 'Smart Home Pty',
-        description: 'RGBW Downlight',
-        extend: generic.light_onoff_brightness_colortemp_colorxy,
-    },
-    {
-        zigbeeModel: ['FNB56-SKT1EHG1.2'],
-        model: 'HGZB-20-DE',
-        vendor: 'Smart Home Pty',
-        description: 'Power plug',
-        supports: 'on/off',
-        fromZigbee: [fz.state_change],
-        toZigbee: [tz.on_off],
     },
 
     // Paul Neuhaus

--- a/devices.js
+++ b/devices.js
@@ -1668,7 +1668,7 @@ const devices = [
     // Nue
     {
         zigbeeModel: ['FB56+ZSW05HG1.2'],
-        model: 'FB56+ZSW05HG1.2' ,
+        model: 'FB56+ZSW05HG1.2',
         vendor: 'Nue',
         description: 'ZigBee one gang wall / in-wall smart switch',
         supports: 'on/off',

--- a/devices.js
+++ b/devices.js
@@ -1694,7 +1694,25 @@ const devices = [
         description: 'ZigBee smart light controller',
         extend: generic.light_onoff_brightness,
     },
-    
+
+    // Smart Home Pty
+    {
+        zigbeeModel: ['FB56-ZCW11HG1.2'],
+        model: 'HGZB-07A',
+        vendor: 'Smart Home Pty',
+        description: 'RGBW Downlight',
+        extend: generic.light_onoff_brightness_colortemp_colorxy,
+    },
+    {
+        zigbeeModel: ['FNB56-SKT1EHG1.2'],
+        model: 'HGZB-20-DE',
+        vendor: 'Smart Home Pty',
+        description: 'Power plug',
+        supports: 'on/off',
+        fromZigbee: [fz.state_change],
+        toZigbee: [tz.on_off],
+    },
+
     // Gledopto
     {
         zigbeeModel: ['GLEDOPTO', 'GL-C-008', 'GL-C-007'],
@@ -1937,24 +1955,6 @@ const devices = [
         },
     },
 
-    // Smart Home Pty
-    {
-        zigbeeModel: ['FB56-ZCW11HG1.2'],
-        model: 'HGZB-07A',
-        vendor: 'Smart Home Pty',
-        description: 'RGBW Downlight',
-        extend: generic.light_onoff_brightness_colortemp_colorxy,
-    },
-    {
-        zigbeeModel: ['FNB56-SKT1EHG1.2'],
-        model: 'HGZB-20-DE',
-        vendor: 'Smart Home Pty',
-        description: 'Power plug',
-        supports: 'on/off',
-        fromZigbee: [fz.state_change],
-        toZigbee: [tz.on_off],
-    },
-
     // Trust
     {
         zigbeeModel: ['ZLL-DimmableLigh'],
@@ -1998,24 +1998,6 @@ const devices = [
 
             execute(device, actions, callback);
         },
-    },
-    
-    // Smart Home Pty
-    {
-        zigbeeModel: ['FB56-ZCW11HG1.2'],
-        model: 'HGZB-07A',
-        vendor: 'Smart Home Pty',
-        description: 'RGBW Downlight',
-        extend: generic.light_onoff_brightness_colortemp_colorxy,
-    },
-    {
-        zigbeeModel: ['FNB56-SKT1EHG1.2'],
-        model: 'HGZB-20-DE',
-        vendor: 'Smart Home Pty',
-        description: 'Power plug',
-        supports: 'on/off',
-        fromZigbee: [fz.state_change],
-        toZigbee: [tz.on_off],
     },
 
     // Paulmann

--- a/devices.js
+++ b/devices.js
@@ -1695,24 +1695,6 @@ const devices = [
         extend: generic.light_onoff_brightness,
     },
     
-    // Smart Home Pty
-    {
-        zigbeeModel: ['FB56-ZCW11HG1.2'],
-        model: 'HGZB-07A',
-        vendor: 'Smart Home Pty',
-        description: 'RGBW Downlight',
-        extend: generic.light_onoff_brightness_colortemp_colorxy,
-    },
-    {
-        zigbeeModel: ['FNB56-SKT1EHG1.2'],
-        model: 'HGZB-20-DE',
-        vendor: 'Smart Home Pty',
-        description: 'Power plug',
-        supports: 'on/off',
-        fromZigbee: [fz.state_change],
-        toZigbee: [tz.on_off],
-    },
-    
     // Gledopto
     {
         zigbeeModel: ['GLEDOPTO', 'GL-C-008', 'GL-C-007'],
@@ -1854,24 +1836,6 @@ const devices = [
             }
         },
     },
-    
-    // Smart Home Pty
-    {
-        zigbeeModel: ['FB56-ZCW11HG1.2'],
-        model: 'HGZB-07A',
-        vendor: 'Smart Home Pty',
-        description: 'RGBW Downlight',
-        extend: generic.light_onoff_brightness_colortemp_colorxy,
-    },
-    {
-        zigbeeModel: ['FNB56-SKT1EHG1.2'],
-        model: 'HGZB-20-DE',
-        vendor: 'Smart Home Pty',
-        description: 'Power plug',
-        supports: 'on/off',
-        fromZigbee: [fz.state_change],
-        toZigbee: [tz.on_off],
-    },
 
     // SmartThings
     {
@@ -1971,6 +1935,24 @@ const devices = [
 
             execute(device, actions, callback);
         },
+    },
+
+    // Smart Home Pty
+    {
+        zigbeeModel: ['FB56-ZCW11HG1.2'],
+        model: 'HGZB-07A',
+        vendor: 'Smart Home Pty',
+        description: 'RGBW Downlight',
+        extend: generic.light_onoff_brightness_colortemp_colorxy,
+    },
+    {
+        zigbeeModel: ['FNB56-SKT1EHG1.2'],
+        model: 'HGZB-20-DE',
+        vendor: 'Smart Home Pty',
+        description: 'Power plug',
+        supports: 'on/off',
+        fromZigbee: [fz.state_change],
+        toZigbee: [tz.on_off],
     },
 
     // Trust

--- a/devices.js
+++ b/devices.js
@@ -1668,7 +1668,7 @@ const devices = [
     // Nue
     {
         zigbeeModel: ['FB56+ZSW05HG1.2'],
-        model: 'HGZB-01A' ,
+        model: 'FB56+ZSW05HG1.2' ,
         vendor: 'Nue',
         description: 'ZigBee one gang wall / in-wall smart switch',
         supports: 'on/off',


### PR DESCRIPTION
FB56+ZSW05HG1.2'  (HGZB-01A)


This device was already supported and works, however error message below. I've added "fz.ignore_onoff_change" to the device handler and this fixes the problem (if it is a problem?), but wanted to check with you @Koenkk that it's okay to ignore the 'genOnOff' message?

```zigbee2mqtt:debug 2/23/2019, 1:31:59 AM Received zigbee message of type 'devChange' with data '{"cid":"genOnOff","data":{"onOff":0}}' of device 'FB56+ZSW05HG1.2' (0x00124b000ae5fa3e)
  zigbee2mqtt:warn 2/23/2019, 1:31:59 AM No converter available for 'FB56+ZSW05HG1.2' with cid 'genOnOff', type 'devChange' and data '{"cid":"genOnOff","data":{"onOff":0}}'
  zigbee2mqtt:warn 2/23/2019, 1:31:59 AM Please see: https://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html.
  zigbee2mqtt:debug 2/23/2019, 1:32:23 AM Received MQTT message on 'zigbee2mqtt/0x00124b000ae5fa3e/set' with data 'ON'
  zigbee2mqtt:info 2/23/2019, 1:32:23 AM Zigbee publish to device '0x00124b000ae5fa3e', genOnOff - on - {} - {"manufSpec":0,"disDefaultRsp":0} - null```

I also moved the "   // Smart Home Pty" devices below // Nue as I believe they are probably the same and before long you might get double ups.