### PR TITLE
fixed thermostat_setpoint_raise_lower / get

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -604,14 +604,6 @@ const converters = {
                     },
                     cfg: cfg.default,
                 };
-            } else if (type === 'get') {
-                return {
-                    cid: cid,
-                    cmd: 'read',
-                    cmdType: 'foundation',
-                    zclData: [{attrId: zclId.attr(cid, attrId).value}],
-                    cfg: cfg.default,
-                };
             }
         },
     },


### PR DESCRIPTION
setpoint_raise_lower is client-to-server only. There is no need for a "get".

To get the setpoint use:
occupied_heating_setpoint
or 
unoccupied_heating_setpoint