### PR TITLE
Additional model name for Osram LIGHTIFY Flex RGBW

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1132,7 +1132,7 @@ const devices = [
         },
     },
     {
-        zigbeeModel: ['Flex RGBW', 'LIGHTIFY Indoor Flex RGBW'],
+        zigbeeModel: ['Flex RGBW', 'LIGHTIFY Indoor Flex RGBW', 'LIGHTIFY Flex RGBW'],
         model: '4052899926110',
         vendor: 'OSRAM',
         description: 'Flex RGBW',


### PR DESCRIPTION
I have an Osram LIGHTIFY Flex indoor light strip that has a slightly different model name