### PR TITLE
Support for 'FB56+ZSW1IKJ1.7' 3-gang Nue Smart Switch

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1709,7 +1709,7 @@ const devices = [
         fromZigbee: [fz.generic_state_multi_ep, fz.ignore_onoff_change],
         toZigbee: [tz.on_off],
         ep: (device) => {
-            return {'left': 16, 'center': 17, 'right': 18};
+            return {'top': 16, 'center': 17, 'bottom': 18};
         },
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const ep16 = shepherd.find(ieeeAddr, 16);

--- a/devices.js
+++ b/devices.js
@@ -1701,6 +1701,28 @@ const devices = [
 
     // Nue, 3A
     {
+        zigbeeModel: ['FB56+ZSW1IKJ1.7'],
+        model: 'HGZB-043',
+        vendor: 'Nue / 3A',
+        description: 'Smart light switch - 3 gang',
+        supports: 'on/off',
+        fromZigbee: [fz.generic_state_multi_ep, fz.ignore_onoff_change],
+        toZigbee: [tz.on_off],
+        ep: (device) => {
+            return {'left': 16, 'center': 17, 'right': 18};
+        },
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const ep16 = shepherd.find(ieeeAddr, 16);
+            execute(ep16, [(cb) => ep16.bind('genOnOff', coordinator, cb)], () => {
+                const ep17 = shepherd.find(ieeeAddr, 17);
+                execute(ep17, [(cb) => ep17.bind('genOnOff', coordinator, cb)], () => {
+                    const ep18 = shepherd.find(ieeeAddr, 18);
+                    execute(ep18, [(cb) => ep18.bind('genOnOff', coordinator, cb)], callback);
+                });
+            });
+        },
+    },   
+    {
         zigbeeModel: ['FB56+ZSW1HKJ1.7'],
         model: 'HGZB-042',
         vendor: 'Nue / 3A',


### PR DESCRIPTION
Confirmed working, but please check my parentheses etc @Koenkk .... I get double MQTT feedback.

It would also be great if you could support 'top' and 'bottom' in https://github.com/Koenkk/zigbee2mqtt/blob/master/lib/extension/devicePublish.js#L8 - is this a possibility? This would make more sense for countries like Australia where switches are mounted vertically, and give the option for the handler to match the local orientation of the device.