### PR TITLE
Clarify that the GE Link bulb could be BR30 or A19

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1547,7 +1547,7 @@ const devices = [
         zigbeeModel: ['ZLL Light'],
         model: '22670',
         vendor: 'GE',
-        description: 'Link smart LED light bulb, BR30 soft white (2700K)',
+        description: 'Link smart LED light bulb, A19/BR30 soft white (2700K)',
         extend: generic.light_onoff_brightness,
     },
     {


### PR DESCRIPTION
I noticed that my A19 GE Link bulbs are sharing the BR30 description.
From what I can tell, they both share same model number: https://github.com/Koenkk/zigbee2mqtt/issues/1161