### PR TITLE
Update devices.js for Nue HGZB-41

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1803,8 +1803,8 @@ const devices = [
     },
     {
         zigbeeModel: ['FNB56-ZSW01LX2.0'],
-        model: 'HGZB-42-UK',
-        description: 'Zigbee smart switch 2 gang',
+        model: 'HGZB-42-UK / HGZB-41',
+        description: 'Zigbee smart switch 1/2 gang',
         vendor: 'Nue / 3A',
         supports: 'on/off',
         fromZigbee: [fz.ignore_onoff_change, fz.state],


### PR DESCRIPTION
The Nue 1 gang smart switch model 'HGZB-41' identifies as 'FNB56-ZSW01LX2.0', the same as previously listed 'HGZB-42-UK' 2 gang switch. Updated model / description to allow for both.