### PR TITLE
Bitron av2010/34 

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -183,6 +183,13 @@ const converters = {
             return {click: 'long_middle'};
         },
     },
+    AV2010_34_click: {
+        cid: 'genScenes',
+        type: 'cmdRecall',
+        convert: (model, msg, publish, options) => {
+            return {click: msg.data.data.groupid};
+        },
+    },
     bitron_power: {
         cid: 'seMetering',
         type: 'attReport',
@@ -2127,6 +2134,11 @@ const converters = {
     ignore_power_change: {
         cid: 'genPowerCfg',
         type: 'devChange',
+        convert: (model, msg, publish, options) => null,
+    },
+    ignore_power_report: {
+        cid: 'genPowerCfg',
+        type: 'attReport',
         convert: (model, msg, publish, options) => null,
     },
     ignore_metering_change: {

--- a/devices.js
+++ b/devices.js
@@ -2234,6 +2234,22 @@ const devices = [
 
     // Bitron
     {
+        zigbeeModel: ['AV2010/34'],
+        model: 'AV2010/34',
+        vendor: 'Bitron',
+        description: '4-Touch Single Click Buttons',
+        supports: '4 Single Click Touch Buttons',
+        fromZigbee: [fz.ignore_power_report, fz.AV2010_34_click],
+        toZigbee: [],
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const device = shepherd.find(ieeeAddr, 1);
+            const actions = [
+                (cb) => device.bind('genPowerCfg', coordinator, cb),
+            ];
+            execute(device, actions, callback);
+        },
+    },
+    {
         zigbeeModel: ['902010/22'],
         model: 'AV2010/22',
         vendor: 'Bitron',

--- a/devices.js
+++ b/devices.js
@@ -2237,8 +2237,8 @@ const devices = [
         zigbeeModel: ['AV2010/34'],
         model: 'AV2010/34',
         vendor: 'Bitron',
-        description: '4-Touch Single Click Buttons',
-        supports: '4 Single Click Touch Buttons',
+        description: '4-Touch single click buttons',
+        supports: 'click',
         fromZigbee: [fz.ignore_power_report, fz.AV2010_34_click],
         toZigbee: [],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {


### PR DESCRIPTION
Support for ``Bitron av2010/34``
- 4 Single Touch Button with Click: ID
- Need cmdID: ``recall``

ToDo: Battery Converter Function. Only AlarmMask is available. Battery Attr Report actually ignored to prevent User from Message Spamming.

Hint: The Beep is physical connected inside the Device themselve. NO Action available to get them Off!