### PR TITLE
Update devices.js to support FB56+ZSW1HKJ2.5 2 gang Nue smart switch

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1805,6 +1805,25 @@ const devices = [
             });
         },
     },
+        {
+        zigbeeModel: ['FB56+ZSW1HKJ2.5'],
+        model: 'HGZB-042',
+        vendor: 'Nue / 3A',
+        description: 'Smart light switch - 2 gang',
+        supports: 'on/off',
+        fromZigbee: [fz.generic_state_multi_ep, fz.ignore_onoff_change],
+        toZigbee: [tz.on_off],
+        ep: (device) => {
+            return {'top': 16, 'bottom': 17};
+        },
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const ep16 = shepherd.find(ieeeAddr, 16);
+            execute(ep16, [(cb) => ep16.bind('genOnOff', coordinator, cb)], () => {
+                const ep17 = shepherd.find(ieeeAddr, 17);
+                execute(ep17, [(cb) => ep17.bind('genOnOff', coordinator, cb)], callback);
+            });
+        },
+    },
     {
         zigbeeModel: ['FB56+ZSW05HG1.2'],
         model: 'FB56+ZSW05HG1.2',

--- a/devices.js
+++ b/devices.js
@@ -1787,26 +1787,7 @@ const devices = [
         fromZigbee: [fz.state, fz.ignore_onoff_change, fz.brightness_report, fz.ignore_light_brightness_change],
     },
     {
-        zigbeeModel: ['FB56+ZSW1HKJ1.7'],
-        model: 'HGZB-042',
-        vendor: 'Nue / 3A',
-        description: 'Smart light switch - 2 gang',
-        supports: 'on/off',
-        fromZigbee: [fz.generic_state_multi_ep, fz.ignore_onoff_change],
-        toZigbee: [tz.on_off],
-        ep: (device) => {
-            return {'top': 16, 'bottom': 17};
-        },
-        configure: (ieeeAddr, shepherd, coordinator, callback) => {
-            const ep16 = shepherd.find(ieeeAddr, 16);
-            execute(ep16, [(cb) => ep16.bind('genOnOff', coordinator, cb)], () => {
-                const ep17 = shepherd.find(ieeeAddr, 17);
-                execute(ep17, [(cb) => ep17.bind('genOnOff', coordinator, cb)], callback);
-            });
-        },
-    },
-        {
-        zigbeeModel: ['FB56+ZSW1HKJ2.5'],
+        zigbeeModel: ['FB56+ZSW1HKJ1.7', 'FB56+ZSW1HKJ2.5'],
         model: 'HGZB-042',
         vendor: 'Nue / 3A',
         description: 'Smart light switch - 2 gang',


### PR DESCRIPTION
This has the same model number HGZB-042 as FB56+ZSW1HKJ1.7