### PR TITLE
Adds IM6001-MTP01 device support.

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2241,6 +2241,31 @@ const devices = [
         },
     },
     {
+        zigbeeModel: ['motion'],
+        model: 'IM6001-MTP01',
+        vendor: 'SmartThings',
+        description: 'Motion sensor (2018 model)',
+        supports: 'occupancy and temperature',
+        fromZigbee: [
+            fz.generic_temperature, fz.ignore_temperature_change,
+            fz.ignore_iaszone_report, fz.ias_zone_motion_dev_change,
+            fz.bosch_ias_zone_motion_status_change, fz.generic_batteryvoltage_3000_2500,
+        ],
+        toZigbee: [],
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const device = shepherd.find(ieeeAddr, 1);
+            const actions = [
+                (cb) => device.write('ssIasZone', 'iasCieAddr', coordinator.device.getIeeeAddr(), cb),
+                (cb) => device.functional('ssIasZone', 'enrollRsp', {enrollrspcode: 0, zoneid: 23}, cb),
+                (cb) => device.bind('msTemperatureMeasurement', coordinator, cb),
+                (cb) => device.report('msTemperatureMeasurement', 'measuredValue', 30, 600, 1, cb),
+                (cb) => device.bind('genPowerCfg', coordinator, cb),
+                (cb) => device.report('genPowerCfg', 'batteryVoltage', 0, 1000, 0, cb),
+            ];
+            execute(device, actions, callback);
+        },
+    },
+    {
         zigbeeModel: ['motionv4'],
         model: 'STS-IRM-250',
         vendor: 'SmartThings',


### PR DESCRIPTION
Adds support for the SmartThings Motion Sensor 2018 model.

[amazon link](https://www.amazon.com/gp/product/B07F8ZHBLS)

Example payload:
`{"occupancy":true,"linkquality":78,"temperature":19.83,"tamper":false,"battery_low":false,"battery":"60.00","voltage":2800}`