### PR TITLE
Fixed incompatible converter on IM6001-MTP01

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1631,6 +1631,18 @@ const converters = {
             };
         },
     },
+    bosch_ias_zone_motion_dev_change: {
+        cid: 'ssIasZone',
+        type: 'devChange',
+        convert: (model, msg, publish, options) => {
+            const zoneStatus = msg.data.zoneStatus;
+            return {
+                occupancy: (zoneStatus & 1) > 0, // Bit 0 = Alarm 1: Presence Indication
+                tamper: (zoneStatus & 1<<2) > 0, // Bit 2 = Tamper status
+                battery_low: (zoneStatus & 1<<3) > 0, // Bit 3 = Battery LOW indicator (trips around 2.4V)
+            };
+        },
+    },
     ias_contact_dev_change: {
         cid: 'ssIasZone',
         type: 'devChange',

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1680,7 +1680,7 @@ const converters = {
             };
         },
     },
-    bosch_ias_zone_motion_dev_change: {
+    generic_ias_zone_motion_dev_change: {
         cid: 'ssIasZone',
         type: 'devChange',
         convert: (model, msg, publish, options) => {

--- a/devices.js
+++ b/devices.js
@@ -2248,7 +2248,7 @@ const devices = [
         supports: 'occupancy and temperature',
         fromZigbee: [
             fz.generic_temperature, fz.ignore_temperature_change,
-            fz.ignore_iaszone_report, fz.ias_zone_motion_dev_change,
+            fz.ignore_iaszone_report, fz.bosch_ias_zone_motion_dev_change,
             fz.bosch_ias_zone_motion_status_change, fz.generic_batteryvoltage_3000_2500,
         ],
         toZigbee: [],

--- a/devices.js
+++ b/devices.js
@@ -2241,6 +2241,31 @@ const devices = [
         },
     },
     {
+        zigbeeModel: ['motion'],
+        model: 'IM6001-MTP01',
+        vendor: 'SmartThings',
+        description: 'Motion sensor (2018 model)',
+        supports: 'occupancy and temperature',
+        fromZigbee: [
+            fz.generic_temperature, fz.ignore_temperature_change,
+            fz.ignore_iaszone_report, fz.ias_zone_motion_dev_change,
+            fz.bosch_ias_zone_motion_status_change, fz.generic_batteryvoltage_3000_2500,
+        ],
+        toZigbee: [],
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const device = shepherd.find(ieeeAddr, 1);
+            const actions = [
+                (cb) => device.write('ssIasZone', 'iasCieAddr', coordinator.device.getIeeeAddr(), cb),
+                (cb) => device.functional('ssIasZone', 'enrollRsp', {enrollrspcode: 0, zoneid: 23}, cb),
+                (cb) => device.bind('msTemperatureMeasurement', coordinator, cb),
+                (cb) => device.report('msTemperatureMeasurement', 'measuredValue', 30, 600, 1, cb),
+                (cb) => device.bind('genPowerCfg', coordinator, cb),
+                (cb) => device.report('genPowerCfg', 'batteryVoltage', 0, 1000, 0, cb),
+            ];
+            execute(device, actions, callback);
+        },
+    },
+    {
         zigbeeModel: ['motionv4'],
         model: 'STS-IRM-250',
         vendor: 'SmartThings',

--- a/devices.js
+++ b/devices.js
@@ -2278,11 +2278,7 @@ const devices = [
         supports: 'occupancy and temperature',
         fromZigbee: [
             fz.generic_temperature, fz.ignore_temperature_change,
-<<<<<<< HEAD
             fz.ignore_iaszone_report, fz.bosch_ias_zone_motion_dev_change,
-=======
-            fz.ignore_iaszone_report, fz.ias_zone_motion_dev_change,
->>>>>>> 65f7b10eb424d7d9d4352613e636e0eba49320c1
             fz.bosch_ias_zone_motion_status_change, fz.generic_batteryvoltage_3000_2500,
         ],
         toZigbee: [],

--- a/devices.js
+++ b/devices.js
@@ -2278,7 +2278,7 @@ const devices = [
         supports: 'occupancy and temperature',
         fromZigbee: [
             fz.generic_temperature, fz.ignore_temperature_change,
-            fz.ignore_iaszone_report, fz.bosch_ias_zone_motion_dev_change,
+            fz.ignore_iaszone_report, fz.generic_ias_zone_motion_dev_change,
             fz.bosch_ias_zone_motion_status_change, fz.generic_batteryvoltage_3000_2500,
         ],
         toZigbee: [],


### PR DESCRIPTION
- Removed incompatible ias_zone_motion_dev_change converter.
- Added bosch_ias_zone_motion_dev_change converter.
- Updated IM6001-MTP01 to use bosch_ias_zone_motion_dev_change converter