### PR TITLE
Basic support for GE Plug-in Smart Switch 45853GE

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1660,6 +1660,25 @@ const devices = [
         },
     },
     {
+        zigbeeModel: ['45853'],
+        model: '45853GE',
+        vendor: 'GE',
+        description: 'Plug-in smart switch',
+        supports: 'on/off',
+        fromZigbee: [fz.state, fz.ignore_onoff_change],
+        toZigbee: [tz.on_off, tz.ignore_transition],
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const cfg = {direction: 0, attrId: 0, dataType: 16, minRepIntval: 0, maxRepIntval: 1000, repChange: 0};
+            const device = shepherd.find(ieeeAddr, 1);
+            const actions = [
+                (cb) => device.bind('genOnOff', coordinator, cb),
+                (cb) => device.foundation('genOnOff', 'configReport', [cfg], foundationCfg, cb),
+            ];
+
+            execute(device, actions, callback);
+        },
+    },
+    {
         zigbeeModel: ['45856'],
         model: '45856GE',
         vendor: 'GE',


### PR DESCRIPTION
Note: does not include energy monitoring functionality

Works for turning it and off.

```
3/26/2019, 7:17:36 AM - info: Zigbee publish to device '0x0022a300001xxxxx', genOnOff - on - {} - {"manufSpec":0,"disDefaultRsp":0} - null
3/26/2019, 7:17:36 AM - info: MQTT publish: topic 'zigbee2mqtt/New Switch', payload '{"state":"ON","linkquality":102}'
3/26/2019, 7:17:36 AM - debug: Received zigbee message of type 'attReport' with data '{"cid":"genOnOff","data":{"onOff":1}}' of device '45853' (0x0022a300001xxxxx)
3/26/2019, 7:17:36 AM - info: MQTT publish: topic 'zigbee2mqtt/New Switch', payload '{"state":"ON","linkquality":105}'
3/26/2019, 7:17:36 AM - debug: Received zigbee message of type 'devChange' with data '{"cid":"genOnOff","data":{"onOff":1}}' of device '45853' (0x0022a300001xxxxx)
3/26/2019, 7:17:36 AM - debug: Received zigbee message of type 'readRsp' with data '{"cid":"genOnOff","data":{"onOff":1}}' of device '45853' (0x0022a300001xxxxx)
3/26/2019, 7:17:36 AM - info: MQTT publish: topic 'zigbee2mqtt/New Switch', payload '{"state":"ON","linkquality":105}'
3/26/2019, 7:17:36 AM - debug: Received zigbee message of type 'devChange' with data '{"cid":"genOnOff","data":{"onOff":1}}' of device '45853' (0x0022a300001xxxxx)
3/26/2019, 7:17:42 AM - debug: Received MQTT message on 'zigbee2mqtt/New Switch/set' with data 'OFF'
3/26/2019, 7:17:42 AM - info: Zigbee publish to device '0x0022a300001xxxxx', genOnOff - off - {} - {"manufSpec":0,"disDefaultRsp":0} - null
3/26/2019, 7:17:42 AM - info: MQTT publish: topic 'zigbee2mqtt/New Switch', payload '{"state":"OFF","linkquality":105}'
3/26/2019, 7:17:42 AM - debug: Received zigbee message of type 'attReport' with data '{"cid":"genOnOff","data":{"onOff":0}}' of device '45853' (0x0022a300001xxxxx)
3/26/2019, 7:17:42 AM - info: MQTT publish: topic 'zigbee2mqtt/New Switch', payload '{"state":"OFF","linkquality":115}'
3/26/2019, 7:17:42 AM - debug: Received zigbee message of type 'devChange' with data '{"cid":"genOnOff","data":{"onOff":0}}' of device '45853' (0x0022a300001xxxxx)
3/26/2019, 7:17:42 AM - debug: Received zigbee message of type 'readRsp' with data '{"cid":"genOnOff","data":{"onOff":0}}' of device '45853' (0x0022a300001xxxxx)
3/26/2019, 7:17:42 AM - info: MQTT publish: topic 'zigbee2mqtt/New Switch', payload '{"state":"OFF","linkquality":115}'
3/26/2019, 7:17:42 AM - debug: Received zigbee message of type 'devChange' with data '{"cid":"genOnOff","data":{"onOff":0}}' of device '45853' (0x0022a300001xxxxx)
```