### PR TITLE
Fix confusing docs related different models

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -187,7 +187,7 @@ const devices = [
         model: 'WXKG03LM',
         vendor: 'Xiaomi',
         description: 'Aqara single key wireless wall switch',
-        supports: 'single, double, hold, release and long click',
+        supports: 'single (and double, hold, release and long click depending on model)',
         fromZigbee: [
             fz.xiaomi_battery_3v, fz.WXKG03LM_click, fz.ignore_basic_change,
             fz.xiaomi_action_click_multistate, fz.ignore_multistate_change,


### PR DESCRIPTION
Fixes confusing docs related to ticket https://github.com/Koenkk/zigbee2mqtt/issues/1326

Found my information here:
https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Xiaomi-WXKG03LM-2016
https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Xiaomi-WXKG03LM-2018