### PR TITLE
Add Philips Hue LTW015

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -821,6 +821,13 @@ const devices = [
         extend: hue.light_onoff_brightness_colortemp,
     },
     {
+        zigbeeModel: ['LTW015'],
+        model: '9290011998B',
+        vendor: 'Philips',
+        description: 'Hue white ambiance E26',
+        extend: hue.light_onoff_brightness_colortemp,
+    },
+    {
         zigbeeModel: ['LTW010', 'LTW001', 'LTW004'],
         model: '8718696548738',
         vendor: 'Philips',


### PR DESCRIPTION
This adds support for the Phillips Hue White ambiance E26 bulb.