### PR TITLE
3315-G added

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2499,6 +2499,34 @@ const devices = [
         },
     },
     {
+        zigbeeModel: ['3315-G'],
+        model: '3315-G',
+        vendor: 'SmartThings',
+        description: 'Water sensor',
+        supports: 'water and temperature',
+        fromZigbee: [
+            fz.generic_temperature, fz.ignore_temperature_change, fz.ignore_power_change,
+            fz.st_leak, fz.st_leak_change, fz.generic_batteryvoltage_3000_2500,
+        ],
+        toZigbee: [],
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const device = shepherd.find(ieeeAddr, 1);
+            const actions = [
+                (cb) => device.bind('msTemperatureMeasurement', coordinator, cb),
+                (cb) => device.report('msTemperatureMeasurement', 'measuredValue', 300, 600, 1, cb),
+                (cb) => device.bind('genPowerCfg', coordinator, cb),
+                (cb) => device.report('genPowerCfg', 'batteryVoltage', 0, 1000, 0, cb),
+                (cb) => device.write('ssIasZone', 'iasCieAddr', coordinator.device.getIeeeAddr(), cb),
+                (cb) => device.report('ssIasZone', 'zoneStatus', 0, 1000, null, cb),
+                (cb) => device.functional('ssIasZone', 'enrollRsp', {
+                    enrollrspcode: 1,
+                    zoneid: 255,
+                }, cb),
+            ];
+            execute(device, actions, callback);
+        },
+    },
+    {
         zigbeeModel: ['button'],
         model: 'IM6001-BTP01',
         vendor: 'SmartThings',


### PR DESCRIPTION
added 3315-G version of Smartthings water leak sensor (just different ID).

relevant homeassistant.js entries (also updated some others for lack of battery/humidity reporting due to manufacturer specific clusters which have not yet been implemented):

    '3310-S': [
        configurations.sensor_temperature, 
        configurations.sensor_battery, 
    ],
    '3315-S': [
        configurations.sensor_temperature, configurations.binary_sensor_water_leak,
        configurations.sensor_battery, 
    ],
    '3315-G': [
        configurations.sensor_temperature, configurations.binary_sensor_water_leak,
        configurations.sensor_battery, 
    ],
