### PR TITLE
Add support for Third Reality RealitySwitch Plus.

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3709,7 +3709,7 @@ const devices = [
         },
     },
 
-     // Third Reality
+    // Third Reality
     {
         zigbeeModel: ['3RSS008Z'],
         model: '3RSS008Z',

--- a/devices.js
+++ b/devices.js
@@ -3718,7 +3718,7 @@ const devices = [
         supports: 'on/off, battery',
         fromZigbee: [
             fz.ignore_onoff_change, fz.state, fz.ignore_genIdentify_change,
-            fz.ignore_basic_change
+            fz.ignore_basic_change,
         ],
         toZigbee: [tz.on_off, tz.ignore_transition],
     },

--- a/devices.js
+++ b/devices.js
@@ -3716,7 +3716,10 @@ const devices = [
         vendor: 'Third Reality, Inc',
         description: 'RealitySwitch Plus',
         supports: 'on/off, battery',
-        fromZigbee: [fz.ignore_onoff_change, fz.state],
+        fromZigbee: [
+            fz.ignore_onoff_change, fz.state, fz.ignore_genIdentify_change,
+            fz.ignore_basic_change
+        ],
         toZigbee: [tz.on_off, tz.ignore_transition],
     },
 ];

--- a/devices.js
+++ b/devices.js
@@ -3713,7 +3713,7 @@ const devices = [
     {
         zigbeeModel: ['3RSS008Z'],
         model: '3RSS008Z',
-        vendor: 'Third Reality, Inc',
+        vendor: 'Third Reality',
         description: 'RealitySwitch Plus',
         supports: 'on/off, battery',
         fromZigbee: [

--- a/devices.js
+++ b/devices.js
@@ -3708,6 +3708,17 @@ const devices = [
             });
         },
     },
+
+     // Third Reality
+    {
+        zigbeeModel: ['3RSS008Z'],
+        model: '3RSS008Z',
+        vendor: 'Third Reality, Inc',
+        description: 'RealitySwitch Plus',
+        supports: 'on/off, battery',
+        fromZigbee: [fz.ignore_onoff_change, fz.state],
+        toZigbee: [tz.on_off, tz.ignore_transition],
+    },
 ];
 
 module.exports = devices.map((device) =>


### PR DESCRIPTION
Tested this out and was able to create a switch in home assistant that allows reporting the state and toggling the switch.  I believe this [device](https://www.amazon.com/RealitySwitch-Plus-RealityAdapter-included-assistants/dp/B07K3TRG6W) also supports indicating the battery level, but I'm not quite sure how to add that support.  Any assistance would be appreciated.  It runs on 2 AA alkaline batteries.  Here is what the row looks like from the database:

```json
{
  "_id": "4K7nkAWZv6006kJV",
  "endpoints": {
    "1": {
      "clusters": {
        "genBasic": {
          "attrs": {
            "10": {},
            "65533": 6,
            "9": 255,
            "appProfileVersion": 0,
            "appVersion": 7,
            "dateCode": "2018-10-26",
            "hwVersion": 3,
            "manufacturerName": "Third Reality, Inc",
            "modelId": "3RSS008Z",
            "powerSource": 3,
            "swBuildId": "v1.01.07",
            "zclVersion": 2
          },
          "dir": {
            "value": 1
          }
        },
        "genGroups": {
          "attrs": {
            "65533": 6,
            "nameSupport": 128
          },
          "dir": {
            "value": 1
          }
        },
        "genIdentify": {
          "attrs": {
            "65533": 6,
            "identifyTime": 157
          },
          "dir": {
            "value": 1
          }
        },
        "genOnOff": {
          "attrs": {
            "65533": 6,
            "onOff": 1
          },
          "dir": {
            "value": 1
          }
        },
        "genOta": {
          "attrs": {
            "65533": 6
          },
          "dir": {
            "value": 1
          }
        },
        "genPowerCfg": {
          "attrs": {
            "65533": 1,
            "batteryVoltage": 34
          },
          "dir": {
            "value": 3
          }
        },
        "genScenes": {
          "attrs": {
            "65533": 6,
            "count": 0,
            "currentGroup": 0,
            "currentScene": 0,
            "nameSupport": 128,
            "sceneValid": 0
          },
          "dir": {
            "value": 1
          }
        }
      },
      "devId": 2,
      "epId": 1,
      "inClusterList": [
        0,
        1,
        3,
        4,
        5,
        6,
        25
      ],
      "outClusterList": [
        1
      ],
      "profId": 260
    }
  },
  "epList": [
    1
  ],
  "id": 9,
  "ieeeAddr": "0x282c02bfffe02f11",
  "joinTime": null,
  "manufId": 4659,
  "manufName": "Third Reality, Inc",
  "modelId": "3RSS008Z",
  "nwkAddr": 14032,
  "powerSource": "Battery",
  "status": "offline",
  "type": "EndDevice"
}
```

I can see the `genPowerCfg` has a `batteryVoltage` attr, but I'm not sure how to convert that to an approximate percentage.