### PR TITLE
Add brightness to the supported features for the Philips Hue dimmer switch

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -895,7 +895,7 @@ const devices = [
         model: '324131092621',
         vendor: 'Philips',
         description: 'Hue dimmer switch',
-        supports: 'on/off',
+        supports: 'on/off, brightness up/down/hold/release',
         fromZigbee: [
             fz._324131092621_ignore_on, fz._324131092621_ignore_off, fz._324131092621_ignore_step,
             fz._324131092621_ignore_stop, fz._324131092621_notification,


### PR DESCRIPTION
I started to test zigbee2mqtt today and was surprised to see that brightness is working fine even if it's not specified in the doc. 