### PR TITLE
Add Yale YRD226HA2619 Support

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -152,6 +152,13 @@ const converters = {
             return {state: msg.data.data.lockState === 2 ? 'UNLOCK' : 'LOCK'};
         },
     },
+    YRD226HA2619_lock: {
+        cid: 'closuresDoorLock',
+        type: ['attReport', 'devChange'],
+        convert: (model, msg, publish, options) => {
+            return {state: msg.data.data.lockState === 2 ? 'UNLOCK' : 'LOCK'};
+        },
+    },
     genOnOff_cmdOn: {
         cid: 'genOnOff',
         type: 'cmdOn',

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1252,7 +1252,7 @@ const converters = {
             }
         },
     },
-    YRD426NRSC_YMF40_lock: {
+    generic_lock: {
         key: ['state'],
         convert: (key, value, message, type, postfix) => {
             const cid = 'closuresDoorLock';

--- a/devices.js
+++ b/devices.js
@@ -3405,9 +3405,9 @@ const devices = [
         zigbeeModel: ['YRD226 TSDB'],
         model: 'YRD226HA2619',
         vendor: 'Yale',
-        description: 'Assure Lock',
+        description: 'Assure lock',
         supports: 'lock/unlock, battery',
-        fromZigbee: [fz.YRD226HA2619_lock, fz.battery_200],
+        fromZigbee: [fz.generic_lock, fz.battery_200],
         toZigbee: [tz.YRD426NRSC_lock],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);
@@ -3425,7 +3425,7 @@ const devices = [
         vendor: 'Yale',
         description: 'Real living lock',
         supports: 'lock/unlock, battery',
-        fromZigbee: [fz.YMF40_lockstatus],
+        fromZigbee: [fz.generic_lock],
         toZigbee: [tz.YRD426NRSC_YMF40_lock],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);

--- a/devices.js
+++ b/devices.js
@@ -3389,8 +3389,8 @@ const devices = [
         vendor: 'Yale',
         description: 'Assure lock',
         supports: 'lock/unlock, battery',
-        fromZigbee: [fz.YRD426NRSC_lock, fz.battery_200],
-        toZigbee: [tz.YRD426NRSC_YMF40_lock],
+        fromZigbee: [fz.generic_lock, fz.battery_200],
+        toZigbee: [tz.generic_lock],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);
             const actions = [
@@ -3408,7 +3408,7 @@ const devices = [
         description: 'Assure lock',
         supports: 'lock/unlock, battery',
         fromZigbee: [fz.generic_lock, fz.battery_200],
-        toZigbee: [tz.YRD426NRSC_lock],
+        toZigbee: [tz.generic_lock],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);
             const actions = [
@@ -3425,8 +3425,8 @@ const devices = [
         vendor: 'Yale',
         description: 'Real living lock',
         supports: 'lock/unlock, battery',
-        fromZigbee: [fz.generic_lock],
-        toZigbee: [tz.YRD426NRSC_YMF40_lock],
+        fromZigbee: [fz.YMF40_lockstatus],
+        toZigbee: [tz.generic_lock],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);
 

--- a/devices.js
+++ b/devices.js
@@ -3402,13 +3402,13 @@ const devices = [
         },
     },
     {
-    	zigbeeModel: ['YRD226 TSDB'],
-    	model: 'YRD226HA2619',
-    	vendor: 'Yale',
-    	description: 'Assure Lock',
-    	supports: 'lock/unlock, battery',
-    	fromZigbee: [fz.YRD226HA2619_lock, fz.battery_200],
-    	toZigbee: [tz.YRD426NRSC_lock],
+        zigbeeModel: ['YRD226 TSDB'],
+        model: 'YRD226HA2619',
+        vendor: 'Yale',
+        description: 'Assure Lock',
+        supports: 'lock/unlock, battery',
+        fromZigbee: [fz.YRD226HA2619_lock, fz.battery_200],
+        toZigbee: [tz.YRD426NRSC_lock],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);
             const actions = [

--- a/devices.js
+++ b/devices.js
@@ -3393,7 +3393,6 @@ const devices = [
         toZigbee: [tz.YRD426NRSC_lock],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);
-
             const actions = [
                 (cb) => device.report('closuresDoorLock', 'lockState', 0, repInterval.HOUR, 0, cb),
                 (cb) => device.report('genPowerCfg', 'batteryPercentageRemaining', 0, repInterval.MAX, 0, cb),
@@ -3402,7 +3401,24 @@ const devices = [
             execute(device, actions, callback);
         },
     },
+    {
+    	zigbeeModel: ['YRD226 TSDB'],
+    	model: 'YRD226HA2619',
+    	vendor: 'Yale',
+    	description: 'Assure Lock',
+    	supports: 'lock/unlock, battery',
+    	fromZigbee: [fz.YRD226HA2619_lock, fz.battery_200],
+    	toZigbee: [tz.YRD426NRSC_lock],
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const device = shepherd.find(ieeeAddr, 1);
+            const actions = [
+                (cb) => device.report('closuresDoorLock', 'lockState', 0, repInterval.HOUR, 0, cb),
+                (cb) => device.report('genPowerCfg', 'batteryPercentageRemaining', 0, repInterval.MAX, 0, cb),
+            ];
 
+            execute(device, actions, callback);
+        },
+    },
     // Keen Home
     {
         zigbeeModel: [


### PR DESCRIPTION
Added device entry in the Device.js and an entry in the fromZigbee.js since this lock uses a different 'type' than the current supported device.