### PR TITLE
Enhancement of Müller Licht tint remote converter

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1993,6 +1993,27 @@ const converters = {
             };
         },
     },
+    tint404011_brightness_updown_hold: {
+        cid: 'genLevelCtrl',
+        type: 'cmdMove',
+        convert: (model, msg, publish, options) => {
+            const direction = msg.data.data.movemode === 1 ? 'down' : 'up';
+            return {
+                action: `brightness_${direction}_hold`,
+                rate: msg.data.data.rate
+            };
+        },
+    },
+    tint404011_brightness_updown_release: {
+        cid: 'genLevelCtrl',
+        type: 'cmdStop',
+        convert: (model, msg, publish, options) => {
+            const direction = msg.data.data.movemode === 1 ? 'down' : 'up';
+            return {
+                action: `brightness_${direction}_release`
+            };
+        },
+    },
     tint404011_scene: {
         cid: 'genBasic',
         type: 'cmdWrite',

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2008,7 +2008,7 @@ const converters = {
 
             return {
                 action: `brightness_${direction}_hold`,
-                rate: msg.data.data.rate
+                rate: msg.data.data.rate,
             };
         },
     },
@@ -2017,12 +2017,13 @@ const converters = {
         type: 'cmdStop',
         convert: (model, msg, publish, options) => {
             const deviceID = msg.endpoints[0].device.ieeeAddr;
-            if (!store[deviceID])
-              return null;
+            if (!store[deviceID]) {
+                return null;
+            }
 
             const direction = store[deviceID].movemode;
             return {
-                action: `brightness_${direction}_release`
+                action: `brightness_${direction}_release`,
             };
         },
     },

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1997,7 +1997,15 @@ const converters = {
         cid: 'genLevelCtrl',
         type: 'cmdMove',
         convert: (model, msg, publish, options) => {
+            const deviceID = msg.endpoints[0].device.ieeeAddr;
             const direction = msg.data.data.movemode === 1 ? 'down' : 'up';
+
+            // Save last direction for release event
+            if (!store[deviceID]) {
+                store[deviceID] = {};
+            }
+            store[deviceID].movemode = direction;
+
             return {
                 action: `brightness_${direction}_hold`,
                 rate: msg.data.data.rate
@@ -2008,7 +2016,11 @@ const converters = {
         cid: 'genLevelCtrl',
         type: 'cmdStop',
         convert: (model, msg, publish, options) => {
-            const direction = msg.data.data.movemode === 1 ? 'down' : 'up';
+            const deviceID = msg.endpoints[0].device.ieeeAddr;
+            if (!store[deviceID])
+              return null;
+
+            const direction = store[deviceID].movemode;
             return {
                 action: `brightness_${direction}_release`
             };

--- a/devices.js
+++ b/devices.js
@@ -3224,7 +3224,7 @@ const devices = [
         fromZigbee: [
             fz.tint404011_on, fz.tint404011_off, fz.cmdToggle, fz.tint404011_brightness_updown_click,
             fz.tint404011_move_to_color_temp, fz.tint404011_move_to_color, fz.tint404011_scene,
-            fz.tint404011_brightness_updown_release, fz.tint404011_brightness_updown_hold
+            fz.tint404011_brightness_updown_release, fz.tint404011_brightness_updown_hold,
         ],
         toZigbee: [],
     },

--- a/devices.js
+++ b/devices.js
@@ -3224,6 +3224,7 @@ const devices = [
         fromZigbee: [
             fz.tint404011_on, fz.tint404011_off, fz.cmdToggle, fz.tint404011_brightness_updown_click,
             fz.tint404011_move_to_color_temp, fz.tint404011_move_to_color, fz.tint404011_scene,
+            fz.tint404011_brightness_updown_release, fz.tint404011_brightness_updown_hold
         ],
         toZigbee: [],
     },


### PR DESCRIPTION
Added converters for brightness button hold/release messages for use with the tint remote model 404011 (ZBT-Remote-ALL-RGBW)