### PR TITLE
Support Feibit Inc co.  FB56-ZCW11HG1.2

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2094,6 +2094,15 @@ const devices = [
         toZigbee: [tz.on_off],
     },
 
+    // Feibit Inc co.  
+    {
+        zigbeeModel: ['FB56-ZCW11HG1.2'],
+        model: 'FB56-ZCW11HG1.2',
+        vendor: 'Feibit Inc co.  ',
+        description: 'RGBW Downlight',
+        extend: generic.light_onoff_brightness_colortemp_colorxy,
+    },
+
     // Gledopto
     {
         zigbeeModel: ['GLEDOPTO', 'GL-C-008', 'GL-C-007'],


### PR DESCRIPTION
This adds support for Feibit Inc co.  FB56-ZCW11HG1.2 RGBW 11w LED Downlight

It seems to be that same as the Smart Home Pty. device that is already added, and shares a Zigbee Model ID. From what I've seen online, there are many versions of this device, I'm guessing they may just be white-label devices.

Z2M showed my light as unsupported until I added this entry to `devices.js`.

There was no need for me to add it to the `homeassistant.js` as it seems entries there are purely based on modelId, and my light was added to home assistant just on the devices.js change.