### PR TITLE
Add Paulmann SmartHome Zigbee Cephei switch controller (500.43)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2703,6 +2703,14 @@ const devices = [
 
     // Paulmann
     {
+        zigbeeModel: ['Switch Controller '],
+        model: '50043',
+        vendor: 'Paulmann',
+        description: 'SmartHome Zigbee Cephei Switch Controller',
+        fromZigbee: [fz.state, fz.state_change],
+        toZigbee: [tz.on_off],
+    },
+    {
         zigbeeModel: ['Dimmablelight '],
         model: '50045',
         vendor: 'Paulmann',

--- a/devices.js
+++ b/devices.js
@@ -2707,6 +2707,7 @@ const devices = [
         model: '50043',
         vendor: 'Paulmann',
         description: 'SmartHome Zigbee Cephei Switch Controller',
+        supports: 'on/off',
         fromZigbee: [fz.state, fz.state_change],
         toZigbee: [tz.on_off],
     },


### PR DESCRIPTION
Acts as a simple on-off switch.

Manufacturer page: [https://en.paulmann.com/indoor-lighting/recessed-downlights/more-recessed-lights/smarthome-zigbee-cephei-switch-controller-max.-1000w-ac/50043](https://en.paulmann.com/indoor-lighting/recessed-downlights/more-recessed-lights/smarthome-zigbee-cephei-switch-controller-max.-1000w-ac/50043)