### PR TITLE
Add support for Paul Neuhaus Q-PLUG Adapter Plug

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2682,11 +2682,6 @@ const converters = {
         type: 'devChange',
         convert: (model, msg, publish, options) => null,
     },
-    ignore_nlg_plug_genBasic: {
-        cid: 'genBasic',
-        type: 'devChange',
-        convert: (model, msg, publish, options) => null,
-    },
 };
 
 module.exports = converters;

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2682,11 +2682,11 @@ const converters = {
         type: 'devChange',
         convert: (model, msg, publish, options) => null,
     },
-    ignore_nlg_plug_genBasic : {
+    ignore_nlg_plug_genBasic: {
         cid: 'genBasic',
         type: 'devChange',
         convert: (model, msg, publish, options) => null,
-    }
+    },
 };
 
 module.exports = converters;

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2682,6 +2682,11 @@ const converters = {
         type: 'devChange',
         convert: (model, msg, publish, options) => null,
     },
+    ignore_nlg_plug_genBasic : {
+        cid: 'genBasic',
+        type: 'devChange',
+        convert: (model, msg, publish, options) => null,
+    }
 };
 
 module.exports = converters;

--- a/devices.js
+++ b/devices.js
@@ -3264,6 +3264,15 @@ const devices = [
         description: 'Q-FLAG LED Panel, Smart-Home RGBW',
         extend: generic.light_onoff_brightness_colortemp_colorxy,
     },
+    {
+        zigbeeModel: ['NLG-plug '],
+        model: '100.425.90',
+        vendor: 'Paul Neuhaus',
+        description: 'Q-PLUG Adapter Plug with night orientation light',
+        supports: 'on/off',
+        fromZigbee: [fz.ignore_nlg_plug_genBasic],
+        toZigbee: [tz.on_off],
+    },
 
     // iCasa
     {

--- a/devices.js
+++ b/devices.js
@@ -3268,9 +3268,9 @@ const devices = [
         zigbeeModel: ['NLG-plug '],
         model: '100.425.90',
         vendor: 'Paul Neuhaus',
-        description: 'Q-PLUG Adapter Plug with night orientation light',
+        description: 'Q-PLUG adapter plug with night orientation light',
         supports: 'on/off',
-        fromZigbee: [fz.ignore_nlg_plug_genBasic],
+        fromZigbee: [fz.ignore_basic_change],
         toZigbee: [tz.on_off],
     },
 


### PR DESCRIPTION
I have added support for the Paul Neuhaus Q-PLUG Adapter Plug. It is an adapter plug that can be controlled via Zigbee. It also features also a night orientation light, but this one can't be switched via zigbee. 

[paul-neuhaus.de Q-PLUG](https://www.paul-neuhaus.de/shop/de/q-led-nachtlicht-smart-home-zwischenstecker-wei-100-425-90.html)

Without the `fz.ignore_nlg_plug_genBasic` I received this message in the log:
`warn: No converter available for '100.425.90' with cid 'genBasic', type 'devChange' and data '{"cid":"genBasic","data":{"zclVersion":1}}'`.
As I don't see any Info of value of the zclVersion I ignored it.

After the changes I can turn the device on and off and I receive this mqtt message:
`{"state":"ON","device":{"ieeeAddr":"0x00158d00025.......","friendlyName":"qplug","type":"Router","nwkAddr":9745,"manufId":4151,"manufName":"Neuhaus Lighting Group ","powerSource":"Mains (single phase)","modelId":"NLG-plug ","hwVersion":1,"swBuildId":"unknown","dateCode":"20160606","status":"online"}}`