### PR TITLE
FIX: Sylvania 'A19 W 10 year' ignore lightingColorCtrl reporting

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1635,6 +1635,7 @@ const devices = [
             fz.ignore_genIdentify_change,
             fz.ignore_diagnostic_change,
             fz.ignore_genScenes_change,
+            fz.ignore_light_color_colortemp_report,
         ]),
     },
     {


### PR DESCRIPTION
Fixes the following warnings in logs:

**`warn: No converter available for '74696' with cid 'lightingColorCtrl',
type 'attReport'`**

This lightbulb is a fixed color and colortemp bulb, so we can ignore `lightingColorCtrl` messages.