### PR TITLE
Add support for Sylvania soft white PAR38 outdoor bulb

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1678,6 +1678,13 @@ const devices = [
         description: 'LIGHTIFY LED gardenspot mini RGB',
         extend: generic.light_onoff_brightness_colorxy,
     },
+	{
+        zigbeeModel: ['PAR38 W 10 year'],
+        model: '74580',
+        vendor: 'Sylvania',
+        description: 'Smart Home soft white PAR38 outdoor bulb',
+        extend: generic.light_onoff_brightness,
+    },
 
     // GE
     {

--- a/devices.js
+++ b/devices.js
@@ -1678,7 +1678,7 @@ const devices = [
         description: 'LIGHTIFY LED gardenspot mini RGB',
         extend: generic.light_onoff_brightness_colorxy,
     },
-	{
+    {
         zigbeeModel: ['PAR38 W 10 year'],
         model: '74580',
         vendor: 'Sylvania',


### PR DESCRIPTION
Added support for this guy: https://consumer.sylvania.com/our-products/smart/product-info/zigbee/sylvania-smart-zigbee-soft-white-par38-bulb/index.jsp