### PR TITLE
Add state reporting to edp redy devices

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1059,7 +1059,7 @@ const devices = [
             ]
             execute(device, actions, callback);
         },
-    }
+    },
 
     // Custom devices (DiY)
     {

--- a/devices.js
+++ b/devices.js
@@ -1050,7 +1050,7 @@ const devices = [
         vendor: 'EDP',
         description: 're:dy switch',
         supports: 'on/off',
-        fromZigbee: [fz.state,, fz.ignore_onoff_change],
+        fromZigbee: [fz.state, fz.ignore_onoff_change],
         toZigbee: [tz.on_off],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 85);

--- a/devices.js
+++ b/devices.js
@@ -1033,11 +1033,15 @@ const devices = [
         vendor: 'EDP',
         description: 're:dy plug',
         supports: 'on/off, power measurement',
-        fromZigbee: [fz.ignore_onoff_change, fz.generic_power, fz.ignore_metering_change],
+        fromZigbee: [fz.state, fz.ignore_onoff_change, fz.generic_power, fz.ignore_metering_change],
         toZigbee: [tz.on_off],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 85);
-            execute(device, [(cb) => device.report('seMetering', 'instantaneousDemand', 10, 60, 1, cb)], callback);
+            const actions = [
+                (cb) => device.report('seMetering', 'instantaneousDemand', 10, 60, 1, cb),
+                (cb) => device.report('genOnOff', 'onOff', 1, 60, 1, cb),
+            ]
+            execute(device, actions, callback);
         },
     },
     {
@@ -1046,9 +1050,16 @@ const devices = [
         vendor: 'EDP',
         description: 're:dy switch',
         supports: 'on/off',
-        fromZigbee: [fz.ignore_onoff_change],
+        fromZigbee: [fz.state,, fz.ignore_onoff_change],
         toZigbee: [tz.on_off],
-    },
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const device = shepherd.find(ieeeAddr, 85);
+            const actions = [
+                (cb) => device.report('genOnOff', 'onOff', 1, 60, 1, cb),
+            ]
+            execute(device, actions, callback);
+        },
+    }
 
     // Custom devices (DiY)
     {

--- a/devices.js
+++ b/devices.js
@@ -1040,7 +1040,7 @@ const devices = [
             const actions = [
                 (cb) => device.report('seMetering', 'instantaneousDemand', 10, 60, 1, cb),
                 (cb) => device.report('genOnOff', 'onOff', 1, 60, 1, cb),
-            ]
+            ];
             execute(device, actions, callback);
         },
     },
@@ -1056,7 +1056,7 @@ const devices = [
             const device = shepherd.find(ieeeAddr, 85);
             const actions = [
                 (cb) => device.report('genOnOff', 'onOff', 1, 60, 1, cb),
-            ]
+            ];
             execute(device, actions, callback);
         },
     },


### PR DESCRIPTION
The devices have a physical button. This makes the state on zigbee2mqtt update whenever the button is pressed.