### PR TITLE
Added a Visonic MCT-340 E door/window contact sensor support

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3777,6 +3777,23 @@ const devices = [
         fromZigbee: [fz.visonic_contact, fz.ignore_power_change],
         toZigbee: [],
     },
+    {
+        zigbeeModel: ['MCT-340 E'],
+        model: 'MCT-340 E',
+        vendor: 'Visonic',
+        description: 'Magnetic door & window contact sensor',
+        supports: 'contact, temperature',
+        fromZigbee: [fz.visonic_contact, fz.ignore_power_change],
+        toZigbee: [],
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const device = shepherd.find(ieeeAddr, 1);
+            const actions = [
+                (cb) => device.write('ssIasZone', 'iasCieAddr', coordinator.device.getIeeeAddr(), cb),
+                (cb) => device.functional('ssIasZone', 'enrollRsp', {enrollrspcode: 0, zoneid: 0}, cb),
+            ];
+            execute(device, actions, callback);
+        },
+    },
 
     // Sunricher
     {

--- a/devices.js
+++ b/devices.js
@@ -3782,7 +3782,7 @@ const devices = [
         model: 'MCT-340 E',
         vendor: 'Visonic',
         description: 'Magnetic door & window contact sensor',
-        supports: 'contact, temperature',
+        supports: 'contact',
         fromZigbee: [fz.visonic_contact, fz.ignore_power_change],
         toZigbee: [],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {


### PR DESCRIPTION
Added and tested Visonic MCT-340 door/window sensors.
Output examples:

1. Door is closed:

{
  "contact": true,
  "tamper": false,
  "battery_low": false,
  "linkquality": 147,
  "last_seen": "2019-05-13T07:35:58+00:00",
  "elapsed": 1844,
  "device": {
    "ieeeAddr": "0x000d6f000b3dd083",
    "friendlyName": "0x000d6f000b3dd083",
    "type": "EndDevice",
    "nwkAddr": 17099,
    "manufId": 4113,
    "manufName": "Visonic",
    "powerSource": "Battery",
    "modelId": "MCT-340 E",
    "hwVersion": "unknown",
    "swBuildId": "unknown",
    "dateCode": "unknown",
    "status": "offline"
  }
}

2. Door is open:

{
  "contact": false,
  "tamper": false,
  "battery_low": false,
}