### PR TITLE
add 4257050-ZHAC Centralite plug

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2992,7 +2992,7 @@ const devices = [
 
     // Centralite Swiss Plug
     {
-        zigbeeModel: ['4256251-RZHAC', '4257050-RZHAC'],
+        zigbeeModel: ['4256251-RZHAC', '4257050-RZHAC', '4257050-ZHAC'],
         model: '4256251-RZHAC',
         vendor: 'Centralite',
         description: 'White Swiss power outlet switch with power meter',


### PR DESCRIPTION
added 4257050-ZHAC to devices.js so it is recognized.  It appears to operate just the same as 4257050-RHAC. I'm a git newbie, I hope I did this right...