### PR TITLE
fix for Bitron Thermostat Battery Alarm reporting

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -245,16 +245,38 @@ const converters = {
             return {occupancy: true};
         },
     },
-    bitron_battery: {
+    bitron_battery_att_report: {
         cid: 'genPowerCfg',
-        type: ['attReport', 'readRsp'],
+        type: 'attReport',
         convert: (model, msg, publish, options) => {
-            const battery = {max: 3200, min: 2500};
-            const voltage = msg.data.data['batteryVoltage'] * 100;
-            return {
-                battery: toPercentage(voltage, battery.min, battery.max),
-                voltage: voltage,
-            };
+            const result = {};
+            if (typeof msg.data.data['batteryVoltage'] == 'number') {
+                const battery = {max: 3200, min: 2500};
+                const voltage = msg.data.data['batteryVoltage'] * 100;
+                result.battery = toPercentage(voltage, battery.min, battery.max);
+                result.voltage = voltage;
+            }
+            if (typeof msg.data.data['batteryAlarmState'] == 'number') {
+                result.battery_alarm_state = msg.data.data['batteryAlarmState'];
+            }
+            return result;
+        },
+    },
+    bitron_battery_dev_change: {
+        cid: 'genPowerCfg',
+        type: 'devChange',
+        convert: (model, msg, publish, options) => {
+            const result = {};
+            if (typeof msg.data.data['batteryVoltage'] == 'number') {
+                const battery = {max: 3200, min: 2500};
+                const voltage = msg.data.data['batteryVoltage'] * 100;
+                result.battery = toPercentage(voltage, battery.min, battery.max);
+                result.voltage = voltage;
+            }
+            if (typeof msg.data.data['batteryAlarmState'] == 'number') {
+                result.battery_alarm_state = msg.data.data['batteryAlarmState'];
+            }
+            return result;
         },
     },
     bitron_thermostat_att_report: {

--- a/devices.js
+++ b/devices.js
@@ -2842,7 +2842,8 @@ const devices = [
         supports: 'temperature, heating/cooling system control',
         fromZigbee: [
             fz.ignore_basic_change, fz.bitron_thermostat_att_report,
-            fz.bitron_thermostat_dev_change, fz.bitron_battery,
+            fz.bitron_thermostat_dev_change, fz.bitron_battery_att_report,
+            fz.bitron_battery_dev_change,
         ],
         toZigbee: [
             tz.thermostat_occupied_heating_setpoint, tz.thermostat_local_temperature_calibration,


### PR DESCRIPTION
fix for Bitron Thermostat Battery Alarm reporting
```
zigbee2mqtt:warn 2019-5-22 08:38:55 No converter available for 'AV2010/32' with cid 'genPowerCfg', type 'devChange' and data '{"cid":"genPowerCfg","data":{"batteryAlarmState":1}}'
zigbee2mqtt:warn 2019-5-22 09:17:31 No converter available for 'AV2010/32' with cid 'genPowerCfg', type 'devChange' and data '{"cid":"genPowerCfg","data":{"batteryVoltage":32}}'
```

