### PR TITLE
Adding support for Philips Aurelle square panel

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -864,6 +864,13 @@ const devices = [
         extend: hue.light_onoff_brightness_colortemp,
     },
     {
+        zigbeeModel: ['LTC013'],
+        model: '3216131P5',
+        vendor: 'Philips',
+        description: 'Hue white ambiance Aurelle square panel light',
+        extend: hue.light_onoff_brightness_colortemp,
+    },
+    {
         zigbeeModel: ['LTC015'],
         model: '3216331P5',
         vendor: 'Philips',


### PR DESCRIPTION
This panel is basically the same as the rectangle version, just square.
I will create a pull request for the homeassistant.js file too.