### PR TITLE
Cosmetic Fix for Blaupunkt SCM-S1 and Adding support Lupus 12031

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3056,6 +3056,17 @@ const devices = [
         toZigbee: [tz.cover_position, tz.cover_open_close],
     },
 
+    // Lupus
+    {
+        zigbeeModel: ['SCM_00.00.03.11TC'],
+        model: '12031',
+        vendor: 'Lupus',
+        description: 'Roller shutter',
+        supports: 'open/close',
+        fromZigbee: [fz.cover_position_report, fz.cover_position, fz.cover_state_change, fz.cover_state_report],
+        toZigbee: [tz.cover_position, tz.cover_open_close],
+    },
+
     // Climax
     {
         zigbeeModel: ['PSS_00.00.00.15TC'],
@@ -3116,15 +3127,6 @@ const devices = [
 
             execute(device, actions, callback);
         },
-    },
-    {
-        zigbeeModel: ['WarningDevice'],
-        model: 'HS1WD',
-        description: 'Smart indoor light siren',
-        supports: 'on/off',
-        vendor: 'HEIMAN',
-        fromZigbee: [fz.state],
-        toZigbee: [tz.on_off],
     },
     {
         zigbeeModel: ['SMOK_V16', 'b5db59bfd81e4f1f95dc57fdbba17931', 'SMOK_YDLV10', 'SmokeSensor-EM'],
@@ -3199,7 +3201,7 @@ const devices = [
         toZigbee: [],
     },
     {
-        zigbeeModel: ['DOOR_TPV13'],
+        zigbeeModel: ['DOOR_TPV13'], // FIX-NEEDED-INVERTED-STATUS
         model: 'HEIMAN-M1',
         vendor: 'HEIMAN',
         description: 'Door sensor',

--- a/devices.js
+++ b/devices.js
@@ -3201,7 +3201,7 @@ const devices = [
         toZigbee: [],
     },
     {
-        zigbeeModel: ['DOOR_TPV13'], // FIX-NEEDED-INVERTED-STATUS
+        zigbeeModel: ['DOOR_TPV13'],
         model: 'HEIMAN-M1',
         vendor: 'HEIMAN',
         description: 'Door sensor',


### PR DESCRIPTION
Cosmetic Fix for Blaupunkt SCM-S1 (SCM-R_00.00.03.15TC) and Adding support Lupus 12031 (SCM_00.00.03.11TC)
Removed WarningDevice from Heiman (need more job on device to make it work)
Heiman M1 Door Sensor work but need a fix because now show inverted status (someone can help?)