### PR TITLE
Add Support OSRAM SMART+ LED CLASSIC E27 RGBW (AC03647)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1216,6 +1216,13 @@ const devices = [
         extend: generic.light_onoff_brightness_colortemp,
     },
     {
+        zigbeeModel: ['CLA60 RGBW Z3'],
+        model: 'AC03647',
+        vendor: 'OSRAM',
+        description: 'SMART+ LED CLASSIC E27 RGBW',
+        extend: generic.light_onoff_brightness_colortemp_colorxy,
+    },
+    {
         // AA70155 is model number of both bulbs.
         zigbeeModel: ['LIGHTIFY A19 Tunable White', 'Classic A60 TW'],
         model: 'AA70155',


### PR DESCRIPTION
Add OSRAM Smart+ ZigBee LED E27 RGBW Bulb
```
zigbeeModel: CLA60 RGBW Z3
Model: AC03647
```