### PR TITLE
added support for HEIMAN HS1CA-E carbon monoxide sensor.

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3368,7 +3368,7 @@ const devices = [
             ];
 
             execute(device, actions, callback, 1000);
-         },        
+        },
     },
 
     // Oujiabao

--- a/devices.js
+++ b/devices.js
@@ -3348,6 +3348,28 @@ const devices = [
             execute(device, actions, callback, 1000);
         },
     },
+    {
+        zigbeeModel: ['COSensor-EM'],
+        model: 'HS1CA-E',
+        vendor: 'HEIMAN',
+        description: 'Smart carbon monoxide sensor',
+        supports: 'carbon monoxide',
+        fromZigbee: [fz.heiman_carbon_monoxide, fz.battery_200, fz.ignore_power_change, fz.ignore_basic_change],
+        toZigbee: [],
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const device = shepherd.find(ieeeAddr, 1);
+            const actions = [
+                (cb) => device.bind('ssIasZone', coordinator, cb),
+                (cb) => device.functional('ssIasZone', 'enrollRsp', {enrollrspcode: 0, zoneid: 23}, cb),
+                (cb) => device.bind('genPowerCfg', coordinator, cb),
+                // Time is in seconds. 65535 means no report. 65534 is max value: 18 hours, 12 minutes 14 seconds.
+                (cb) => device.report('genPowerCfg', 'batteryPercentageRemaining', 0, 65534, 0, cb),
+                (cb) => device.report('genPowerCfg', 'batteryAlarmState', 1, 65534, 1, cb),
+            ];
+
+            execute(device, actions, callback, 1000);
+         },        
+    },
 
     // Oujiabao
     {


### PR DESCRIPTION
Support for the HEIMAN HS1CA-E smart carbon monoxide sensor.