### PR TITLE
Support hold event for QBKG04LM (Aqara single light switch)

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -973,7 +973,7 @@ const converters = {
         type: 'devChange',
         convert: (model, msg, publish, options) => {
             if (msg.endpoints[0].epId == 4) {
-                return {button_single: msg.data.data['onOff'] === 1 ? 'release' : 'hold'};
+                return {action: msg.data.data['onOff'] === 1 ? 'release' : 'hold'};
             }
         },
     },

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -968,6 +968,15 @@ const converters = {
             }
         },
     },
+    QBKG04LM_buttons: {
+        cid: 'genOnOff',
+        type: 'devChange',
+        convert: (model, msg, publish, options) => {
+            if (msg.endpoints[0].epId == 4) {
+                return {button_single: msg.data.data['onOff'] === 1 ? 'release' : 'hold'};
+            }
+        },
+    },
     QBKG04LM_QBKG11LM_operation_mode: {
         cid: 'genBasic',
         type: 'devChange',

--- a/devices.js
+++ b/devices.js
@@ -219,7 +219,7 @@ const devices = [
         description: 'Aqara single key wired wall switch without neutral wire. Doesn\'t work as a router and doesn\'t support power meter',
         supports: 'on/off',
         fromZigbee: [
-            fz.QBKG04LM_QBKG11LM_state, fz.ignore_onoff_change,
+            fz.QBKG04LM_QBKG11LM_state, fz.QBKG04LM_buttons,
             fz.QBKG04LM_QBKG11LM_operation_mode, fz.ignore_basic_report,
         ],
         toZigbee: [tz.on_off, tz.xiaomi_switch_operation_mode],

--- a/devices.js
+++ b/devices.js
@@ -217,7 +217,7 @@ const devices = [
         vendor: 'Xiaomi',
         // eslint-disable-next-line
         description: 'Aqara single key wired wall switch without neutral wire. Doesn\'t work as a router and doesn\'t support power meter',
-        supports: 'on/off',
+        supports: 'release/hold, on/off',
         fromZigbee: [
             fz.QBKG04LM_QBKG11LM_state, fz.QBKG04LM_buttons,
             fz.QBKG04LM_QBKG11LM_operation_mode, fz.ignore_basic_report,


### PR DESCRIPTION
Added support for hold event in the same way as it's done for QBKG03LM. I have both devices and was able to test it - looks like it works well.