### PR TITLE
Add Xiaomi WSDCGQ01LM identified by lumi.sensor_ht

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -273,7 +273,7 @@ const devices = [
         },
     },
     {
-        zigbeeModel: ['lumi.sens'],
+        zigbeeModel: ['lumi.sens', 'lumi.sensor_ht'],
         model: 'WSDCGQ01LM',
         vendor: 'Xiaomi',
         description: 'MiJia temperature & humidity sensor',


### PR DESCRIPTION
For some reason unbeknownst to me, one of my WSDCGQ01LM Xiaomi temperature & humidity sensors doesn’t identify itself by “lumi.sens” but by “lumi.sensor_ht”

This pull request adds the different identifier.