### PR TITLE
Add generic_lock_operation_event support for Danalock V3 BT/ZB device

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -4188,7 +4188,7 @@ const devices = [
         vendor: 'Danalock',
         description: 'BT/ZB smartlock',
         supports: 'lock/unlock, battery',
-        fromZigbee: [fz.generic_lock, fz.battery_200],
+        fromZigbee: [fz.generic_lock, fz.generic_lock_operation_event, fz.battery_200],
         toZigbee: [tz.generic_lock],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);


### PR DESCRIPTION
I found warnings for my Danalock V3 BT/ZB lock.

zigbee2mqtt:warn 6/25/2019, 7:43:13 AM No converter available for 'V3-BTZB' with cid 'closuresDoorLock', type 'cmdOperationEventNotification' and data '{"cid":"closuresDoorLock","data":{"opereventsrc":1,"opereventcode":1,"userid":65535,"pin":0,"zigbeelocaltime":4294967295,"data":0}}'
...
zigbee2mqtt:warn 6/25/2019, 8:16:45 AM No converter available for 'V3-BTZB' with cid 'closuresDoorLock', type 'cmdOperationEventNotification' and data '{"cid":"closuresDoorLock","data":{"opereventsrc":1,"opereventcode":2,"userid":65535,"pin":0,"zigbeelocaltime":4294967295,"data":0}}'

It looks like devices.js lacks closuresDoorLock/cmdOperationEventNotification support for V3-BTZB device.