### PR TITLE
Fix Danalock V3 warnings and generic_lock converter

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -149,7 +149,9 @@ const converters = {
         cid: 'closuresDoorLock',
         type: ['attReport', 'readRsp', 'devChange'],
         convert: (model, msg, publish, options) => {
-            return {state: msg.data.data.lockState === 2 ? 'UNLOCK' : 'LOCK'};
+            if (msg.data.data.hasOwnProperty('lockState')) {
+                return {state: msg.data.data.lockState == 2 ? 'UNLOCK' : 'LOCK'};
+            }
         },
     },
     generic_lock_operation_event: {

--- a/devices.js
+++ b/devices.js
@@ -4188,7 +4188,7 @@ const devices = [
         vendor: 'Danalock',
         description: 'BT/ZB smartlock',
         supports: 'lock/unlock, battery',
-        fromZigbee: [fz.generic_lock, fz.battery_200],
+        fromZigbee: [fz.generic_lock, fz.generic_lock_operation_event, fz.battery_200, fz.ignore_power_change],
         toZigbee: [tz.generic_lock],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);


### PR DESCRIPTION
Fix yet another warnings for Danalock V3

```
zigbee2mqtt:warn 6/26/2019, 10:05:00 AM No converter available for 'V3-BTZB' with cid 'genPowerCfg', type 'devChange' and data '{"cid":"genPowerCfg","data":{"batteryPercentageRemaining":198}}'
zigbee2mqtt:warn 6/26/2019, 10:05:00 AM Please see: https://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html.
```

Fix generic_lock to not report lock state if lockState property is absent.
Message example from my lock:
```
zigbee2mqtt:debug 6/26/2019, 11:21:06 AM Received zigbee message of type 'devChange' with data '{"cid":"closuresDoorLock","data":{"lockState":2}}' of device 'V3-BTZB' (0x000b57fffe59cdda) of endpoint 1
zigbee2mqtt:info 6/26/2019, 11:21:06 AM MQTT publish: topic 'zigbee2mqtt/door_lock', payload '{"state":"UNLOCK","linkquality":89,"battery":100,"battery_low":false,"user":65535,"source":1}'
...
zigbee2mqtt:debug 6/26/2019, 11:21:07 AM Received zigbee message of type 'readRsp' with data '{"cid":"closuresDoorLock","data":{"numOfPinUsersSupported":0,"numOfRfidUsersSupported":0,"numOfWeekDaySchedulesSupportedPerUser":0,"numOfYearDaySchedulesSupportedPerUser":0,"numOfHolidayScheduledsSupported":0}}' of device 'V3-BTZB' (0x000b57fffe59cdda) of endpoint 1
zigbee2mqtt:info 6/26/2019, 11:21:07 AM MQTT publish: topic 'zigbee2mqtt/door_lock', payload '{"state":"LOCK","linkquality":92,"battery":99,"battery_low":false,"user":65535,"source":1}'
```