### PR TITLE
Added support for Philips Hue Fuzo Outdoor Wall Light (1744530P7)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1045,6 +1045,13 @@ const devices = [
         description: 'Hue white ambiance Aurelle rectangle panel light',
         extend: hue.light_onoff_brightness_colortemp,
     },
+    {
+        zigbeeModel: ['1744530P7'],
+        model: '1744530P7',
+        vendor: 'Philips',
+        description: 'Hue Fuzo Outdoor Wall Light',
+        extend: hue.light_onoff_brightness,
+    },
 
     // Belkin
     {

--- a/devices.js
+++ b/devices.js
@@ -1047,9 +1047,9 @@ const devices = [
     },
     {
         zigbeeModel: ['1744530P7'],
-        model: '1744530P7',
+        model: '8718696170625',
         vendor: 'Philips',
-        description: 'Hue Fuzo Outdoor Wall Light',
+        description: 'Hue Fuzo outdoor wall light',
         extend: hue.light_onoff_brightness,
     },
 


### PR DESCRIPTION
See title. I could not find the zigbeeModel for this device anywhere so I used the 'raw' model.

https://www2.meethue.com/en-gb/p/hue-white-fuzo-outdoor-wall-light/1744430P7
