### PR TITLE
Added support for HGZB-42 and added script to get number of supported devices/vendors

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2151,26 +2151,25 @@ const devices = [
             });
         },
     },
-                 
     // This product is not compatible with the HGZB-042 device above as it has a different EP config.
     {
-         zigbeeModel: ['FNB56-ZSW02LX2.0'],
-         model: 'HGZB-42',
-         vendor: 'Nue / 3A',
-         description: 'Smart light switch - 2 gang. ',
-         supports: 'on/off',
-         fromZigbee: [fz.generic_state_multi_ep, fz.ignore_onoff_change],
-         toZigbee: [tz.on_off],
-         ep: (device) => {
-         return {'top': 11, 'bottom': 12};
-         },
-         configure: (ieeeAddr, shepherd, coordinator, callback) => {
-         const ep11 = shepherd.find(ieeeAddr, 11);
-         execute(ep11, [(cb) => ep11.bind('genOnOff', coordinator, cb)], () => {
-                 const ep12 = shepherd.find(ieeeAddr, 12);
-                 execute(ep12, [(cb) => ep12.bind('genOnOff', coordinator, cb)], callback);
-                 });
-         },
+        zigbeeModel: ['FNB56-ZSW02LX2.0'],
+        model: 'HGZB-42',
+        vendor: 'Nue / 3A',
+        description: 'Smart light switch - 2 gang. ',
+        supports: 'on/off',
+        fromZigbee: [fz.generic_state_multi_ep, fz.ignore_onoff_change],
+        toZigbee: [tz.on_off],
+        ep: (device) => {
+            return {'top': 11, 'bottom': 12};
+        },
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const ep11 = shepherd.find(ieeeAddr, 11);
+            execute(ep11, [(cb) => ep11.bind('genOnOff', coordinator, cb)], () => {
+                const ep12 = shepherd.find(ieeeAddr, 12);
+                execute(ep12, [(cb) => ep12.bind('genOnOff', coordinator, cb)], callback);
+            });
+        },
     },
     {
         zigbeeModel: ['FB56+ZSW05HG1.2'],

--- a/devices.js
+++ b/devices.js
@@ -2151,6 +2151,27 @@ const devices = [
             });
         },
     },
+                 
+    // This product is not compatible with the HGZB-042 device above as it has a different EP config.
+    {
+         zigbeeModel: ['FNB56-ZSW02LX2.0'],
+         model: 'HGZB-42',
+         vendor: 'Nue / 3A',
+         description: 'Smart light switch - 2 gang. ',
+         supports: 'on/off',
+         fromZigbee: [fz.generic_state_multi_ep, fz.ignore_onoff_change],
+         toZigbee: [tz.on_off],
+         ep: (device) => {
+         return {'top': 11, 'bottom': 12};
+         },
+         configure: (ieeeAddr, shepherd, coordinator, callback) => {
+         const ep11 = shepherd.find(ieeeAddr, 11);
+         execute(ep11, [(cb) => ep11.bind('genOnOff', coordinator, cb)], () => {
+                 const ep12 = shepherd.find(ieeeAddr, 12);
+                 execute(ep12, [(cb) => ep12.bind('genOnOff', coordinator, cb)], callback);
+                 });
+         },
+    },
     {
         zigbeeModel: ['FB56+ZSW05HG1.2'],
         model: 'HGZB-01A/02A',

--- a/get_devices_count.py
+++ b/get_devices_count.py
@@ -1,0 +1,28 @@
+import re
+
+regex = r"zigbeeModel: (\[.*\])"
+
+deviceFile = open("devices.js","r").read()
+
+matches = re.finditer(regex, deviceFile, re.MULTILINE)
+device_groups = list()
+
+for match_num, match in enumerate(matches, start=1):    
+    for group_num in range(0, len(match.groups())):
+        group_num = group_num + 1
+        device_groups.append(match.group(group_num))
+
+zigbee_models = list()
+
+for x in device_groups:
+    zigbee_models.append(x.replace("[", "").replace("]", "").replace("'", "").replace("\"", ""))
+
+model_count = 0
+
+for x in zigbee_models:
+    if x.count(","):
+        model_count += x.count(",") + 1
+    else:
+        model_count += 1
+
+print(str(model_count) + " unique ZigBee models and " + str(len(device_groups)) + " devices supported.")

--- a/get_devices_count.py
+++ b/get_devices_count.py
@@ -1,10 +1,22 @@
 import re
 
 regex = r"zigbeeModel: (\[.*\])"
+vendor_regex = r"vendor: \'(.*)\'"
 
 deviceFile = open("devices.js","r").read()
 
+vendor_matches = re.finditer(vendor_regex, deviceFile, re.MULTILINE)
 matches = re.finditer(regex, deviceFile, re.MULTILINE)
+
+unique_vendors = list()
+
+for match in vendor_matches:
+    if match.groups()[0] not in unique_vendors:
+        unique_vendors.append(match.groups()[0])
+
+vendor_count = len(unique_vendors)
+
+
 device_groups = list()
 
 for match_num, match in enumerate(matches, start=1):    
@@ -25,4 +37,4 @@ for x in zigbee_models:
     else:
         model_count += 1
 
-print(str(model_count) + " unique ZigBee models and " + str(len(device_groups)) + " devices supported.")
+print("{} unique ZigBee models and {} devices supported from {} vendors.".format(model_count, str(len(device_groups)), vendor_count))


### PR DESCRIPTION
I've added support for the Nue / 3A HGZB-42.

I've also created a python script that parses the devices.js file with regex to calculate the total number of ZigBee Models, devices, and vendors that are supported. Just run it `python get_devices_count.py` and it will print out the results. This should make it much easier to keep the numbers at the top of the supported_devices documentation page up to date. :) 