### PR TITLE
 Add support for UK Hive Bulb E27 & B22 - Warm to cool white 

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1483,7 +1483,7 @@ const devices = [
     },
     {
         zigbeeModel: ['TWBulb01UK'],
-        model: 'HALIGHTTUNEW-E27-B22',
+        model: 'HV-GSCXZB279 || HV-GSCXZB229',
         vendor: 'Hive',
         description: 'Active light, warm to cool white (E27 & B22)',
         extend: generic.light_onoff_brightness_colortemp,

--- a/devices.js
+++ b/devices.js
@@ -1481,6 +1481,13 @@ const devices = [
         description: 'Active light cool to warm white (E26) ',
         extend: generic.light_onoff_brightness_colortemp,
     },
+    {
+        zigbeeModel: ['TWBulb01UK'],
+        model: 'HALIGHTTUNEW-E27-B22',
+        vendor: 'Hive',
+        description: 'Active light, warm to cool white (E27 & B22)',
+        extend: generic.light_onoff_brightness_colortemp,
+    },
 
     // Innr
     {

--- a/devices.js
+++ b/devices.js
@@ -1483,7 +1483,7 @@ const devices = [
     },
     {
         zigbeeModel: ['TWBulb01UK'],
-        model: 'HV-GSCXZB279 || HV-GSCXZB229',
+        model: 'HV-GSCXZB279_HV-GSCXZB229',
         vendor: 'Hive',
         description: 'Active light, warm to cool white (E27 & B22)',
         extend: generic.light_onoff_brightness_colortemp,


### PR DESCRIPTION
Both E27 and B22 variants of the bulb report a Zigbee model of TWBulb01UK.