### PR TITLE
Add support for ROB_200-004-0

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2504,7 +2504,7 @@ const devices = [
             execute(device, actions, callback);
         },
     },
-    
+
     // SmartThings
     {
         zigbeeModel: ['PGC313'],

--- a/devices.js
+++ b/devices.js
@@ -2483,6 +2483,28 @@ const devices = [
         },
     },
 
+    // Robbshop
+    {
+        zigbeeModel: ['ROB_200-004-0'],
+        model: 'ROB_200-004-0',
+        vendor: 'Robbshop',
+        description: 'ZigBee AC phase-cut dimmer',
+        supports: 'on/off, brightness',
+        fromZigbee: [fz.brightness, fz.ignore_onoff_change, fz.state, fz.ignore_light_brightness_report],
+        toZigbee: [tz.light_onoff_brightness, tz.ignore_transition],
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const cfg = {direction: 0, attrId: 0, dataType: 16, minRepIntval: 0, maxRepIntval: 1000, repChange: 0};
+            const device = shepherd.find(ieeeAddr, 1);
+            const actions = [
+                (cb) => device.bind('genOnOff', coordinator, cb),
+                (cb) => device.foundation('genOnOff', 'configReport', [cfg], foundationCfg, cb),
+                (cb) => device.bind('genLevelCtrl', coordinator, cb),
+            ];
+
+            execute(device, actions, callback);
+        },
+    },
+    
     // SmartThings
     {
         zigbeeModel: ['PGC313'],

--- a/devices.js
+++ b/devices.js
@@ -2483,11 +2483,11 @@ const devices = [
         },
     },
 
-    // Robbshop
+    // ROBB
     {
         zigbeeModel: ['ROB_200-004-0'],
         model: 'ROB_200-004-0',
-        vendor: 'Robbshop',
+        vendor: 'ROBB',
         description: 'ZigBee AC phase-cut dimmer',
         supports: 'on/off, brightness',
         fromZigbee: [fz.brightness, fz.ignore_onoff_change, fz.state, fz.ignore_light_brightness_report],


### PR DESCRIPTION
Add support for ROB_200-004-0 a ZigBee AC phase-cut dimmer, it is the same form factor as the [Sunricher - ZG9101SAC-HP](http://www.zigbee2mqtt.io/devices/ZG9101SAC-HP).  But then sold under a different name/vendor here in The Netherlands. 

The same config as Sunricher does work (```extend: generic.light_onoff_brightness,```) but the state does not change when a button is pressed / dimmed. That's why I changed it.

The only thing I found strange is, that I had too define ```fz.ignore_light_brightness_report``` otherwise I got the following "error" 

```
No converter available for 'ROB_200-004-0' with cid 'genLevelCtrl', type 'attReport' and data '{"cid":"genLevelCtrl","data":{"currentLevel":16}}'
```

But the brightness Is reporting a correct value. 



```
PM MQTT publish: topic 'zigbee2mqtt/light_switch_1', payload '{"state":"OFF","brightness":33,"linkquality":15,"last_seen":1562880834536}'
PM MQTT publish: topic 'zigbee2mqtt/light_switch_1', payload '{"state":"ON","brightness":33,"linkquality":15,"last_seen":1562880836040}'
PM MQTT publish: topic 'zigbee2mqtt/light_switch_1', payload '{"state":"ON","brightness":46,"linkquality":15,"last_seen":1562880841750}'
PM MQTT publish: topic 'zigbee2mqtt/light_switch_1', payload '{"state":"ON","brightness":88,"linkquality":15,"last_seen":1562880842753}'

```` 