### PR TITLE
Add additional model identifier used by Sylvania 75693 bulbs

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1761,7 +1761,7 @@ const devices = [
         ]),
     },
     {
-        zigbeeModel: ['LIGHTIFY A19 RGBW'],
+        zigbeeModel: ['LIGHTIFY A19 RGBW', 'A19 RGBW'],
         model: '73693',
         vendor: 'Sylvania',
         description: 'LIGHTIFY LED RGBW A19',


### PR DESCRIPTION
This model identifier is used by the "Sylvania Smart+" branded RGBW bulbs in the A19 form factor, running the latest US firmware as of the time of this PR.