### PR TITLE
Add support for Sinope line volt thermostat (TH1123ZB)

### DIFF
--- a/converters/common.js
+++ b/converters/common.js
@@ -44,10 +44,24 @@ const fanMode = {
     'auto': 5,
     'smart': 6,
 };
+const temperatureDisplayMode = {
+    0: 'celsius',
+    1: 'fahrenheit',
+};
+const keypadLockoutMode = {
+    0: 'unlock',
+    1: 'lock1',
+    2: 'lock2',
+    3: 'lock3',
+    4: 'lock4',
+    5: 'lock5',
+};
 
 module.exports = {
     thermostatControlSequenceOfOperations,
     thermostatSystemModes,
     thermostatRunningStates,
     fanMode,
+    temperatureDisplayMode,
+    keypadLockoutMode,
 };

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1555,9 +1555,10 @@ const converters = {
             }
         },
     },
+
     // Sinope
     sinope_thermostat_backlight_autodim_param: {
-        key: 'backlightAutoDimParam',
+        key: 'backlight_auto_dim',
         convert: (key, value, message, type, postfix, options) => {
             const cid = 'hvacThermostat';
             const attrId = 0x0402;
@@ -1581,7 +1582,7 @@ const converters = {
         },
     },
     sinope_thermostat_enable_outdoor_temperature: {
-        key: 'enableOutdoorTemperature',
+        key: 'enable_outdoor_temperature',
         convert: (key, value, message, type, postfix, options) => {
             const cid = 0xFF01;
             const attrId = 0x0011;
@@ -1615,7 +1616,7 @@ const converters = {
         },
     },
     sinope_thermostat_outdoor_temperature: {
-        key: 'thermostatOutdoorTemperature',
+        key: 'thermostat_outdoor_temperature',
         convert: (key, value, message, type, postfix, options) => {
             const cid = 0xFF01;
             const attrId = 0x0010;
@@ -1635,7 +1636,7 @@ const converters = {
         },
     },
     sinope_thermostat_time: {
-        key: 'thermostatTime',
+        key: 'thermostat_time',
         convert: (key, value, message, type, postfix, options) => {
             const cid = 0xFF01;
             const attrId = 0x0020;

--- a/devices.js
+++ b/devices.js
@@ -4750,7 +4750,7 @@ const devices = [
         zigbeeModel: ['TH1123ZB'],
         model: 'TH1123ZB',
         vendor: 'Sinope',
-        description: 'Zigbee Line Volt thermostat',
+        description: 'Zigbee line volt thermostat',
         supports: 'local temp, units, keypad lockout, mode, state, backlight, outdoor temp, time',
         fromZigbee: [
             fz.thermostat_att_report, fz.thermostat_dev_change,

--- a/devices.js
+++ b/devices.js
@@ -4732,6 +4732,42 @@ const devices = [
             execute(device, actions, callback);
         },
     },
+
+    // Sinope
+    {
+        zigbeeModel: ['TH1123ZB'],
+        model: 'TH1123ZB',
+        vendor: 'Sinope',
+        description: 'Zigbee Line Volt thermostat',
+        supports: 'local temp, units, keypad lockout, mode, state, backlight, outdoor temp, time',
+        fromZigbee: [
+            fz.thermostat_att_report, fz.thermostat_dev_change,
+        ],
+        toZigbee: [
+            tz.thermostat_local_temperature, tz.thermostat_occupancy,
+            tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,
+            tz.thermostat_temperature_display_mode, tz.thermostat_keypad_lockout,
+            tz.thermostat_system_mode, tz.thermostat_running_state,
+            tz.sinope_thermostat_backlight_autodim_param, tz.sinope_thermostat_time,
+            tz.sinope_thermostat_enable_outdoor_temperature, tz.sinope_thermostat_outdoor_temperature,
+        ],
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const device = shepherd.find(ieeeAddr, 1);
+            const actions = [
+                (cb) => device.bind('genBasic', coordinator, cb),
+                (cb) => device.bind('genIdentify', coordinator, cb),
+                (cb) => device.bind('genGroups', coordinator, cb),
+                (cb) => device.bind('hvacThermostat', coordinator, cb),
+                (cb) => device.bind('hvacUserInterfaceCfg', coordinator, cb),
+                (cb) => device.bind('msTemperatureMeasurement', coordinator, cb),
+                (cb) => device.report('hvacThermostat', 'localTemp', 19, 300, 50, cb),
+                (cb) => device.report('hvacThermostat', 'pIHeatingDemand', 4, 300, 10, cb),
+                (cb) => device.report('hvacThermostat', 'occupiedHeatingSetpoint', 15, 300, 40, cb),
+            ];
+            execute(device, actions, callback);
+        },
+    },
+
 ];
 
 module.exports = devices.map((device) =>


### PR DESCRIPTION
Hi,

This pull request is to support [Sinope Zigbee line volt thermostats ](https://www.sinopetech.com/en/products/thermostat/line-voltage/).

It features: 
- local temperatures
- unit selections
- keypad lockout
- system mode
- running mode
- lcd backlight mode (custom attribute)
- outdoor temperature (custom attribute)
- time (custom attribute)

The current limitations are:
- the modelId (TH1123ZB) has to be written manually in the database.db file (not ideal...)
- everytime the coordinator start 2 custom attributes are reported (I could not find a way to have custom clusterid in the fromZigbee.js)
- occupancy cannot be changed

I am open to any suggestion
Thank you


