### PR TITLE
Added support for the latest Philips Hue color bulbs

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -803,6 +803,13 @@ const devices = [
         extend: hue.light_onoff_brightness_colortemp_colorxy,
     },
     {
+        zigbeeModel: ['LCA002'],
+        model: '9290022166',
+        vendor: 'Philips',
+        description: 'Hue white and color ambiance E26',
+        extend: hue.light_onoff_brightness_colortemp_colorxy,
+    },
+    {
         zigbeeModel: ['LCT001', 'LCT007', 'LCT010', 'LCT012', 'LCT014', 'LCT015', 'LCT016'],
         model: '9290012573A',
         vendor: 'Philips',


### PR DESCRIPTION
Hello,
I just added a few lines of codes to support the newest Philips color bulbs (model 9290022166, LCA002/ US/Canada w/ Bluetooth). These are available in the US and Canadian markets. Tested and seems to work fine.
Best.