### PR TITLE
Some improvements

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -867,6 +867,15 @@ const converters = {
             return {water_leak: msg.data.zoneStatus === 1};
         },
     },
+    SJCGQ11LM_water_leak_interval: {
+        cid: 'genBasic',
+        type: ['attReport', 'readRsp'],
+        convert: (model, msg, publish, options) => {
+            if (msg.data.data.hasOwnProperty('65281')) {
+                return {water_leak: msg.data.data['65281']['100'] === 1};
+            }
+        },
+    },
     state: {
         cid: 'genOnOff',
         type: ['attReport', 'readRsp'],
@@ -2960,6 +2969,39 @@ const converters = {
         convert: (model, msg, publish, options) => {
             if (msg.data.data.hasOwnProperty('currentTemperature')) {
                 return {temperature: msg.data.data.currentTemperature};
+            }
+        },
+    },
+    ptvo_switch_state: {
+        cid: 'genOnOff',
+        type: 'attReport',
+        convert: (model, msg, publish, options) => {
+            const ep = msg.endpoints[0];
+            const key = `state_${getKey(model.ep(ep.device), ep.epId)}`;
+            const payload = {};
+            payload[key] = msg.data.data['onOff'] === 1 ? 'ON' : 'OFF';
+            return payload;
+        },
+    },
+    ptvo_switch_buttons: {
+        cid: 'genMultistateInput',
+        type: 'attReport',
+        convert: (model, msg, publish, options) => {
+            const ep = msg.endpoints[0];
+            const button = getKey(model.ep(ep.device), ep.epId);
+            const value = msg.data.data['presentValue'];
+
+            const actionLookup = {
+                1: 'single',
+                2: 'double',
+                3: 'tripple',
+                4: 'hold',
+            };
+
+            const action = actionLookup[value];
+
+            if (button) {
+                return {click: button + (action ? `_${action}` : '')};
             }
         },
     },

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1727,6 +1727,50 @@ const converters = {
             }
         },
     },
+    ptvo_switch_trigger: {
+        key: ['trigger', 'interval'],
+        convert: (key, value, message, type, postfix, options) => {
+            console.log('ptvo_switch_trigger:', key, value, message, type, postfix);
+            if (type === 'set') {
+                value = parseInt(value);
+                if (!value) {
+                    return;
+                }
+
+                const cid = 'genOnOff';
+
+                if (key === 'trigger') {
+                    return [{
+                        cid: cid,
+                        cmd: 'onWithTimedOff',
+                        cmdType: 'functional',
+                        zclData: {
+                            ctrlbits: 0,
+                            ontime: value,
+                            offwaittime: 0,
+                        },
+                        cfg: cfg.default,
+                    }];
+                } else if (key === 'interval') {
+                    const attrId = 'onOff';
+                    return [{
+                        cid: cid,
+                        cmd: 'configReport',
+                        cmdType: 'foundation',
+                        zclData: [{
+                            direction: 0,
+                            dataType: zclId.attrType(cid, attrId).value,
+                            attrData: value,
+                            minRepIntval: value,
+                            maxRepIntval: value,
+                        }],
+                        cfg: cfg.default,
+                    }];
+                }
+            }
+            return;
+        },
+    },
 
     /**
      * Ignore converters

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1759,7 +1759,8 @@ const converters = {
                         cmdType: 'foundation',
                         zclData: [{
                             direction: 0,
-                            dataType: zclId.attrType(cid, attrId).value,
+                            attrId: Zcl.getAttributeLegacy(cid, attrId).value,
+                            dataType: Zcl.getAttributeTypeLegacy(cid, attrId).value,
                             attrData: value,
                             minRepIntval: value,
                             maxRepIntval: value,

--- a/devices.js
+++ b/devices.js
@@ -1159,7 +1159,9 @@ const devices = [
         vendor: 'Custom devices (DiY)',
         description: '[Multi-channel relay switch](https://ptvo.info/zigbee-switch-configurable-firmware-router-199/)',
         supports: 'hold, single, double and triple click, on/off',
-        fromZigbee: [fz.ptvo_switch_state, fz.ptvo_switch_buttons, fz.ignore_onoff_change, fz.ignore_multistate_change],
+        fromZigbee: [fz.ptvo_switch_state, fz.ptvo_switch_buttons,
+            fz.ignore_basic_change, fz.ignore_onoff_change, fz.ignore_multistate_change,
+        ],
         toZigbee: [tz.on_off, tz.ptvo_switch_trigger],
         ep: (device) => {
             return {'bottom_left': 1, 'bottom_right': 2, 'top_left': 3, 'top_right': 4, 'center': 5};

--- a/devices.js
+++ b/devices.js
@@ -349,7 +349,10 @@ const devices = [
         vendor: 'Xiaomi',
         description: 'Aqara water leak sensor',
         supports: 'water leak true/false',
-        fromZigbee: [fz.xiaomi_battery_3v, fz.SJCGQ11LM_water_leak_iaszone, fz.ignore_basic_change],
+        fromZigbee: [
+            fz.xiaomi_battery_3v, fz.SJCGQ11LM_water_leak_iaszone,
+            fz.SJCGQ11LM_water_leak_interval, fz.ignore_basic_change,
+        ],
         toZigbee: [],
     },
     {
@@ -1148,7 +1151,19 @@ const devices = [
         description: '[CC2530 router](http://ptvo.info/cc2530-based-zigbee-coordinator-and-router-112/)',
         supports: 'state, description, type, rssi',
         fromZigbee: [fz.CC2530ROUTER_state, fz.CC2530ROUTER_meta, fz.ignore_onoff_change],
-        toZigbee: [],
+        toZigbee: [tz.ptvo_switch_trigger],
+    },
+    {
+        zigbeeModel: ['ptvo.switch'],
+        model: 'ptvo.switch',
+        vendor: 'Custom devices (DiY)',
+        description: '[Multi-channel relay switch](https://ptvo.info/zigbee-switch-configurable-firmware-router-199/)',
+        supports: 'hold, single, double and triple click, on/off',
+        fromZigbee: [fz.ptvo_switch_state, fz.ptvo_switch_buttons, fz.ignore_onoff_change, fz.ignore_multistate_change],
+        toZigbee: [tz.on_off, tz.ptvo_switch_trigger],
+        ep: (device) => {
+            return {'bottom_left': 1, 'bottom_right': 2, 'top_left': 3, 'top_right': 4, 'center': 5};
+        },
     },
     {
         zigbeeModel: ['DNCKAT_S001'],


### PR DESCRIPTION
1. Added support for a configurable 4-channel switch DIY device (https://ptvo.info/zigbee-switch-configurable-firmware-router-199/). @Koenkk The `center_left` button renamed to `center`. I've re-checked, and it works.

2. Added the `interval` command for the router device. It allows changing the regular report interval (`interval => 65535`, disables reporting at all, and the red light too).

3. Added decoding for periodic reports for SJCGQ11LM.