### PR TITLE
Add support for SmartThings Water Leak sensor (2018 model)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2908,6 +2908,34 @@ const devices = [
         },
     },
     {
+        zigbeeModel: ['water'],
+        model: 'F-WTR-UK-V2',
+        vendor: 'SmartThings',
+        description: 'Water Leak sensor (2018 model)',
+        supports: 'water and temperature',
+        fromZigbee: [
+            fz.generic_temperature, fz.ignore_temperature_change, fz.ignore_power_change,
+            fz.st_leak, fz.st_leak_change, fz.generic_batteryvoltage_3000_2500,
+        ],
+        toZigbee: [],
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const device = shepherd.find(ieeeAddr, 1);
+            const actions = [
+                (cb) => device.bind('msTemperatureMeasurement', coordinator, cb),
+                (cb) => device.report('msTemperatureMeasurement', 'measuredValue', 300, 600, 1, cb),
+                (cb) => device.bind('genPowerCfg', coordinator, cb),
+                (cb) => device.report('genPowerCfg', 'batteryVoltage', 0, 1000, 0, cb),
+                (cb) => device.write('ssIasZone', 'iasCieAddr', coordinator.device.getIeeeAddr(), cb),
+                (cb) => device.report('ssIasZone', 'zoneStatus', 0, 1000, null, cb),
+                (cb) => device.functional('ssIasZone', 'enrollRsp', {
+                    enrollrspcode: 1,
+                    zoneid: 255,
+                }, cb),
+            ];
+            execute(device, actions, callback);
+        },
+    },
+    {
         zigbeeModel: ['3315-G'],
         model: '3315-G',
         vendor: 'SmartThings',

--- a/devices.js
+++ b/devices.js
@@ -2911,8 +2911,8 @@ const devices = [
         zigbeeModel: ['water'],
         model: 'F-WTR-UK-V2',
         vendor: 'SmartThings',
-        description: 'Water Leak sensor (2018 model)',
-        supports: 'water and temperature',
+        description: 'Water leak sensor (2018 model)',
+        supports: 'water leak and temperature',
         fromZigbee: [
             fz.generic_temperature, fz.ignore_temperature_change, fz.ignore_power_change,
             fz.st_leak, fz.st_leak_change, fz.generic_batteryvoltage_3000_2500,


### PR DESCRIPTION
Add support for SmartThings Water Leak sensor (2018 model)
Model number: F-WTR-UK-V2