### PR TITLE
Adds support for the Keen SV02 6x10 vent

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -4165,7 +4165,7 @@ const devices = [
         },
     },
     {
-        zigbeeModel: ['SV02-410-MP-1.3'],
+        zigbeeModel: ['SV02-410-MP-1.3', 'SV02-610-MP-1.3'],
         model: 'SV02',
         vendor: 'Keen Home',
         description: 'Smart vent',


### PR DESCRIPTION
The SV02 support works for both the 4x10 and the 6x10 vents. This just adds the 6x10 zigbeeModel to the SV02 spec.