### PR TITLE
IKEA TRADFRI E1810

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -652,7 +652,7 @@ const devices = [
     },
     {
         zigbeeModel: ['TRADFRI remote control'],
-        model: 'E1524',
+        model: 'E1524/E1810',
         description: 'TRADFRI remote control',
         supports:
             'toggle, arrow left/right click/hold/release, brightness up/down click/hold/release',


### PR DESCRIPTION
Add the IKEA E1810, which appears to be a replacement for the E1524. Functionally, they appear to
work identically, the only difference I can see is front finish is matte rather than glossy, and
the internals behind the battery cover are slightly different.

I chose not the rename the `fz.E1524_arrow_click` etc functions, i believe it's easy enough to trace back from the E1810 references to those if necessary.

**Read note on zigbee2mqtt PR @ https://github.com/Koenkk/zigbee2mqtt/pull/1866 before merging.**