### PR TITLE
Update devices.js

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1119,6 +1119,13 @@ const devices = [
         description: 'Hue Fuzo outdoor wall light',
         extend: hue.light_onoff_brightness,
     },
+    {
+        zigbeeModel: ['1743630P7'],
+        model: '17436/30/P7',
+        vendor: 'Philips',
+        description: 'Hue Welcome white flood light',
+        extend: hue.light_onoff_brightness,
+    },
 
     // Belkin
     {


### PR DESCRIPTION
Add support for the Philips Hue Welcome white flood light.
This is the warm white only version.
Device details: http://www.p4c.philips.com/cgi-bin/cpindex.pl?ctn=1743630P7&hlt=Link_ProductInformation&mid=Link_ProductInformation&scy=FR&slg=AEN
Image link: https://images.philips.com/is/image/PhilipsConsumer/1743630P7-RTP-global-001?wid=2000&hei=2000&$jpglarge$