### PR TITLE
Support Hue white ambiance E26 with Bluetooth

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -926,6 +926,13 @@ const devices = [
         extend: hue.light_onoff_brightness_colortemp,
     },
     {
+        zigbeeModel: ['LTA002'],
+        model: '9290022167',
+        vendor: 'Philips',
+        description: 'Hue white ambiance E26 with Bluetooth',
+        extend: hue.light_onoff_brightness_colortemp,
+    },
+    {
         zigbeeModel: ['LTW010', 'LTW001', 'LTW004'],
         model: '8718696548738',
         vendor: 'Philips',


### PR DESCRIPTION
Support new Philips Hue bulb that has Bluetooth in addition to Zigbee.  We don't care about the BT, but it's a new device with a new model ID, so here we are.