### PR TITLE
Add Piri gas sensor

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -5522,6 +5522,23 @@ const devices = [
             execute(ep1, actions, callback);
         },
     },
+    {
+        zigbeeModel: ['GASSensor-EM'],
+        model: 'HSIO18008',
+        vendor: 'Piri',
+        description: 'Combustible gas sensor',
+        supports: 'gas',
+        fromZigbee: [fz.piri_gas, fz.ignore_iaszone_change],
+        toZigbee: [],
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const device = shepherd.find(ieeeAddr, 1);
+            const actions = [
+                (cb) => device.write('ssIasZone', 'iasCieAddr', coordinator.device.getIeeeAddr(), cb),
+                (cb) => device.functional('ssIasZone', 'enrollRsp', {enrollrspcode: 0, zoneid: 23}, cb),
+            ];
+            execute(device, actions, callback);
+        },
+    },
 ];
 
 module.exports = devices.map((device) =>


### PR DESCRIPTION
https://www.piri.shop/pl/p/Czujnik-gazu-ziemnego-Bezprzewodowy-Aplikacja-PIRI-na-IOS-i-Android-Wbudowana-syrena-alarmowa/45