### PR TITLE
added support of new zigbeeModel for Nue/3A - HGZB42 and HGZB-43, smart light switch

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2325,7 +2325,7 @@ const devices = [
         extend: generic.light_onoff_brightness,
     },
     {
-        zigbeeModel: ['FNB56-ZSW03LX2.0'],
+        zigbeeModel: ['FNB56-ZSW03LX2.0', 'LXN-3S27LX1.0'],
         model: 'HGZB-43',
         vendor: 'Nue / 3A',
         description: 'Smart light switch - 3 gang v2.0',

--- a/devices.js
+++ b/devices.js
@@ -2397,10 +2397,10 @@ const devices = [
         },
     },
     {
-        zigbeeModel: ['FNB56-ZSW02LX2.0'],
+        zigbeeModel: ['FNB56-ZSW02LX2.0', 'LXN-2S27LX1.0'],
         model: 'HGZB-42',
         vendor: 'Nue / 3A',
-        description: 'Smart light switch - 2 gang. ',
+        description: 'Smart light switch - 2 gang v2.0',
         supports: 'on/off',
         fromZigbee: [fz.generic_state_multi_ep, fz.ignore_onoff_change],
         toZigbee: [tz.on_off],

--- a/devices.js
+++ b/devices.js
@@ -2416,7 +2416,7 @@ const devices = [
         },
     },
     {
-        zigbeeModel: ['FB56+ZSW1GKJ2.5'],
+        zigbeeModel: ['FB56+ZSW1GKJ2.5', 'LXN-1S27LX1.0'],
         model: 'HGZB-41',
         vendor: 'Nue / 3A',
         description: 'Smart one gang wall switch',


### PR DESCRIPTION
added this zigbeeModel to the HGZB-43 and it works
{"type":"device_connected","message":"0x00158d00044a9364","meta":{"modelID":"LXN-3S27LX1.0"}}
