### PR TITLE
Add icasa ICZB-IW11SW switch

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3950,7 +3950,9 @@ const devices = [
         model: 'ICZB-IW11SW',
         vendor: 'iCasa',
         description: 'Zigbee 3.0 Switch',
-        extend: generic.light_onoff_brightness,
+	supports: 'on/off',
+	fromZigbee: [fz.state],
+	toZigbee: [tz.on_off],
     },
 
     // Müller Licht

--- a/devices.js
+++ b/devices.js
@@ -3945,6 +3945,13 @@ const devices = [
         description: 'Zigbee 3.0 Dimmer',
         extend: generic.light_onoff_brightness,
     },
+    {
+        zigbeeModel: ['ICZB-IW11SW'],
+        model: 'ICZB-IW11SW',
+        vendor: 'iCasa',
+        description: 'Zigbee 3.0 Switch',
+        extend: generic.light_onoff_brightness,
+    },
 
     // Müller Licht
     {

--- a/devices.js
+++ b/devices.js
@@ -3950,9 +3950,9 @@ const devices = [
         model: 'ICZB-IW11SW',
         vendor: 'iCasa',
         description: 'Zigbee 3.0 Switch',
-	supports: 'on/off',
-	fromZigbee: [fz.state],
-	toZigbee: [tz.on_off],
+        supports: 'on/off',
+        fromZigbee: [fz.state],
+        toZigbee: [tz.on_off],
     },
 
     // Müller Licht


### PR DESCRIPTION
The zigbee2mqtt logging shows when the device is turned on and turned off. Only question I have is it uses generic.light_onoff_brightness because there is no generic.light_onoff.... is that ok?