### PR TITLE
add support for SR-ZG9001K4-DIM2

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -4668,6 +4668,14 @@ const devices = [
         description: 'ZigBee AC phase-cut dimmer',
         extend: generic.light_onoff_brightness,
     },
+    {
+        zigbeeModel: ['ZG2833K4_EU06'],
+        model: 'SR-ZG9001K4-DIM2',
+        vendor: 'Sunricher',
+        description: 'ZigBee double key wall switch',
+        toZigbee: [],
+        fromZigbee: [fz.genOnOff_cmdOn, fz.genOnOff_cmdOff, fz.cmd_move_with_onoff, fz.cmd_stop_with_onoff, fz.generic_battery],
+    },
 
     // Shenzhen Homa
     {

--- a/devices.js
+++ b/devices.js
@@ -4673,8 +4673,11 @@ const devices = [
         model: 'SR-ZG9001K4-DIM2',
         vendor: 'Sunricher',
         description: 'ZigBee double key wall switch',
+        fromZigbee: [
+          fz.genOnOff_cmdOn, fz.genOnOff_cmdOff, fz.cmd_move_with_onoff, fz.cmd_stop_with_onoff, fz.generic_battery,
+          fz.ignore_basic_change, fz.ignore_diagnostic_change, fz.ignore_power_change
+        ],
         toZigbee: [],
-        fromZigbee: [fz.genOnOff_cmdOn, fz.genOnOff_cmdOff, fz.cmd_move_with_onoff, fz.cmd_stop_with_onoff, fz.generic_battery],
     },
 
     // Shenzhen Homa

--- a/devices.js
+++ b/devices.js
@@ -4676,7 +4676,7 @@ const devices = [
         supports: 'on/off, brightness',
         fromZigbee: [
             fz.genOnOff_cmdOn, fz.genOnOff_cmdOff, fz.cmd_move_with_onoff, fz.cmd_stop_with_onoff, fz.generic_battery,
-            fz.ignore_basic_change, fz.ignore_diagnostic_change, fz.ignore_power_change
+            fz.ignore_basic_change, fz.ignore_diagnostic_change, fz.ignore_power_change,
         ],
         toZigbee: [],
     },

--- a/devices.js
+++ b/devices.js
@@ -4673,9 +4673,10 @@ const devices = [
         model: 'SR-ZG9001K4-DIM2',
         vendor: 'Sunricher',
         description: 'ZigBee double key wall switch',
+        supports: 'on/off, brightness',
         fromZigbee: [
-          fz.genOnOff_cmdOn, fz.genOnOff_cmdOff, fz.cmd_move_with_onoff, fz.cmd_stop_with_onoff, fz.generic_battery,
-          fz.ignore_basic_change, fz.ignore_diagnostic_change, fz.ignore_power_change
+            fz.genOnOff_cmdOn, fz.genOnOff_cmdOff, fz.cmd_move_with_onoff, fz.cmd_stop_with_onoff, fz.generic_battery,
+            fz.ignore_basic_change, fz.ignore_diagnostic_change, fz.ignore_power_change
         ],
         toZigbee: [],
     },


### PR DESCRIPTION
I'm not sure what `toZigbee` should be.

iCasa and ROBB offer rebrands of this product; could add support if requested (do not own them though).



**edit** ~noticed a couple of more warnings, will fix;~ fixed
<details>

```
zigbee2mqtt:warn 9/14/2019, 10:36:40 PM No converter available for 'SR-ZG9001K4-DIM2' with cid 'genPowerCfg', type 'devChange' and data '{"cid":"genPowerCfg","data":{"batteryPercentageRemaining":100}}'
```

```
  zigbee2mqtt:warn 9/14/2019, 10:36:37 PM No converter available for 'SR-ZG9001K4-DIM2' with cid 'genBasic', type 'devChange' and data '{"cid":"genBasic","data":{"10":[48,48]}}'
```

```
  zigbee2mqtt:warn 9/14/2019, 10:36:21 PM No converter available for 'SR-ZG9001K4-DIM2' with cid 'genPowerCfg', type 'devChange' and data '{"cid":"genPowerCfg","data":{"batteryVoltage":30,"batterySize":255,"batteryQuantity":0,"batteryVoltMinThres":0}}'
 ```

```
  zigbee2mqtt:warn 9/14/2019, 10:36:22 PM No converter available for 'SR-ZG9001K4-DIM2' with cid 'genPowerCfg', type 'devChange' and data '{"cid":"genPowerCfg","data":{"65533":1,"batteryVoltThres1":0,"batteryVoltThres2":0,"batteryVoltThres3":0,"batteryAlarmState":0}}'
```

```
  zigbee2mqtt:warn 9/14/2019, 10:36:31 PM No converter available for 'SR-ZG9001K4-DIM2' with cid 'haDiagnostic', type 'devChange' and data '{"cid":"haDiagnostic","data":{"lastMessageRssi":-67}}'
```

```
  zigbee2mqtt:warn 9/14/2019, 10:36:14 PM No converter available for 'SR-ZG9001K4-DIM2' with cid 'genBasic', type 'devChange' and data '{"cid":"genBasic","data":{"manufacturerName":"Sunricher","modelId":"ZG2833K4_EU06","powerSource":3}}'
```

```
  zigbee2mqtt:warn 9/14/2019, 10:36:16 PM No converter available for 'SR-ZG9001K4-DIM2' with cid 'genBasic', type 'devChange' and data '{"cid":"genBasic","data":{"zclVersion":2,"appVersion":0,"stackVersion":0,"hwVersion":0,"dateCode":"NULL","swBuildId":"2.2.3_r11"}}'
```

</details>