### PR TITLE
HIVE GU10 cool/worm white bulb added

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1665,6 +1665,13 @@ const devices = [
         description: 'Active light, warm to cool white (E27 & B22)',
         extend: generic.light_onoff_brightness_colortemp,
     },
+    {
+        zigbeeModel: ['TWGU10Bulb01UK'],
+        model: 'HV-GUCXZB5',
+        vendor: 'Hive',
+        description: 'Active light, warm to cool white (GU10)',
+        extend: generic.light_onoff_brightness_colortemp,
+    },
 
     // Innr
     {


### PR DESCRIPTION
Added support for the Hive Light Cool to Warm White Smart Bulb GU10 5.4 W [Energy Class A+].
https://www.amazon.co.uk/Hive-Light-Cool-White-Smart/dp/B07B3B46CB/ref=sr_1_2?crid=18GTW197F20UO&keywords=hive+gu10&qid=1568615894&s=gateway&sprefix=hive+gu10%2Caps%2C204&sr=8-2

This bulb acts the same as E27 Hive bulb