### PR TITLE
Fixed_color_capability_for_device_PAR16_RGBW_Z3

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1533,7 +1533,7 @@ const devices = [
         model: 'AC08559',
         vendor: 'OSRAM',
         description: 'SMART+ Spot GU10 Multicolor',
-        extend: generic.light_onoff_brightness_colortemp,
+        extend: generic.light_onoff_brightness_colortemp_colorxy,
     },
     {
         zigbeeModel: ['B40 DIM Z3'],


### PR DESCRIPTION
LEDVANCE - PAR16_RGBW_Z3 had no converter for color.

Simply changed the configuration and it works.