### PR TITLE
Added support for Paul Neuhaus ceiling lamp Model 100.110.39 in devices.js

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3957,7 +3957,7 @@ const devices = [
         zigbeeModel: ['Neuhaus NLG-TW light'],
         model: '100.469.65',
         vendor: 'Paul Neuhaus',
-        description: 'Q-INIGO, LED Panel, Smart-Home RGB',
+        description: 'Q-INIGO, LED panel, Smart-Home RGB',
         extend: generic.light_onoff_brightness_colortemp,
     },
     {


### PR DESCRIPTION
Added necessary settings for model 100.110.39 to the Paul Neuhaus section of devices.js. 