### PR TITLE
Added support for Philips Hue White GU10 bluetooth

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -856,6 +856,13 @@ const devices = [
         extend: hue.light_onoff_brightness,
     },
     {
+        zigbeeModel: ['LWG004'],
+        model: 'LWG004',
+        vendor: 'Philips',
+        description: 'Hue white GU10 bluetooth',
+        extend: hue.light_onoff_brightness,
+    },
+    {
         zigbeeModel: ['LST001'],
         model: '7299355PH',
         vendor: 'Philips',


### PR DESCRIPTION
Added support for Philips Hue White GU10 bluetooth bulbs (same as LWG001 but supports controlling by bluetooth as well).