### PR TITLE
Add 'side' when processing flip90

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -552,12 +552,7 @@ const converters = {
             else if (value >= 256) action = {'action': 'slide', 'side': value-256};
             else if (value >= 128) action = {'action': 'flip180', 'side': value-128};
             else if (value >= 64) {
-                action = {
-                    'action': 'flip90',
-                    'from_side': Math.floor((value-64) / 8),
-                    'to_side': value % 8,
-                    'side': value % 8,
-                };
+                action = {action: 'flip90', from_side: Math.floor((value-64) / 8), to_side: value % 8, side: value % 8};
             }
 
             return action ? action : null;

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -552,7 +552,7 @@ const converters = {
             else if (value >= 256) action = {'action': 'slide', 'side': value-256};
             else if (value >= 128) action = {'action': 'flip180', 'side': value-128};
             else if (value >= 64) {
-                action = {'action': 'flip90', 'from_side': Math.floor((value-64) / 8), 'to_side': value % 8};
+                action = {'action': 'flip90', 'from_side': Math.floor((value-64) / 8), 'to_side': value % 8, 'side': value % 8};
             }
 
             return action ? action : null;

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -552,7 +552,12 @@ const converters = {
             else if (value >= 256) action = {'action': 'slide', 'side': value-256};
             else if (value >= 128) action = {'action': 'flip180', 'side': value-128};
             else if (value >= 64) {
-                action = {'action': 'flip90', 'from_side': Math.floor((value-64) / 8), 'to_side': value % 8, 'side': value % 8};
+                action = {
+                    'action': 'flip90',
+                    'from_side': Math.floor((value-64) / 8),
+                    'to_side': value % 8,
+                    'side': value % 8,
+                };
             }
 
             return action ? action : null;


### PR DESCRIPTION
Add 'side' when processing flip90 so there is a single common attribute to check which face is up.
Fixes #641 