### PR TITLE
Added support for Gledopto wall switch (GL-W-001Z)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -4,6 +4,8 @@ const debug = require('debug')('zigbee-shepherd-converters:devices');
 const fz = require('./converters/fromZigbee');
 const tz = require('./converters/toZigbee');
 
+const store = {};
+
 const repInterval = {
     MAX: 62000,
     HOUR: 3600,

--- a/devices.js
+++ b/devices.js
@@ -2740,8 +2740,21 @@ const devices = [
         model: 'GL-W-001Z',
         vendor: 'Gledopto',
         description: 'Zigbee ON/OFF Wall Switch',
-        supports: 'state: ON/OFF',
-        extend: gledopto.light_onoff_brightness,
+        supports: 'on/off',
+        fromZigbee: [fz.state],
+        toZigbee: [tz.on_off],
+        onEvent: async (type, data, device) => {
+            // This device doesn't support reporting.
+            // Therefore we read the on/off state every 5 seconds.
+            // This is the same way as the Hue bridge does it.
+            if (type === 'stop') {
+                clearInterval(store[device.ieeeAddr]);
+            } else if (!store[device.ieeeAddr]) {
+                store[device.ieeeAddr] = setInterval(async () => {
+                    await device.endpoints[0].read('genOnOff', ['onOff']);
+                }, 5000);
+            }
+        },
     },
 
     // ROBB

--- a/devices.js
+++ b/devices.js
@@ -2735,6 +2735,14 @@ const devices = [
             }
         },
     },
+    {
+        zigbeeModel: ['GL-W-001Z'],
+        model: 'GL-W-001Z',
+        vendor: 'Gledopto',
+        description: 'Zigbee ON/OFF Wall Switch',
+        supports: 'state: ON/OFF',
+        extend: gledopto.light_onoff_brightness,
+    },
 
     // ROBB
     {


### PR DESCRIPTION
Added support for Gledopto wall switch (GL-W-001Z) 
https://www.aliexpress.com/item/4000159569978.html?spm=a2g0s.9042311.0.0.55af4c4dJiyzoA

1 limitation:
– The wall switch does not report its status to the coordinator when it is manually switched on/off.
– I have another one connected to my hue bridge, which also does not report to hue.