### PR TITLE
Support for LWA004 Philips Hue Filament A60/E27 bluetooth

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -828,6 +828,13 @@ const devices = [
         extend: hue.light_onoff_brightness_colortemp_colorxy,
     },
     {
+        zigbeeModel: ['LWA004'],
+        model: '8718699688820',
+        vendor: 'Philips',
+        description: 'Hue Filament Standard A60/E27 bluetooth',
+        extend: hue.light_onoff_brightness,
+    },
+    {
         zigbeeModel: ['LWB004'],
         model: '433714',
         vendor: 'Philips',


### PR DESCRIPTION
Support for LWA004 Philips Hue Filament A60/E27 bluetooth
