### PR TITLE
Add support for PEQ 3300-P contact sensor

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -5642,14 +5642,13 @@ const devices = [
         },
     },
 
-
     // PEQ
     {
         zigbeeModel: ['3300'],
         model: '3300-P',
         vendor: 'PEQ',
         description: 'Door & window contact sensor',
-        supports: 'contact and temperature',
+        supports: 'contact, temperature',
         fromZigbee: [
             fz.generic_temperature, fz.ignore_temperature_change, fz.smartsense_multi,
             fz.ias_contact_status_change, fz.ignore_iaszone_change, fz.generic_batteryvoltage_3000_2500,

--- a/devices.js
+++ b/devices.js
@@ -5641,6 +5641,37 @@ const devices = [
             execute(device, actions, callback);
         },
     },
+
+
+    // PEQ
+    {
+        zigbeeModel: ['3300'],
+        model: '3300-P',
+        vendor: 'PEQ',
+        description: 'Door & window contact sensor',
+        supports: 'contact and temperature',
+        fromZigbee: [
+            fz.generic_temperature, fz.ignore_temperature_change, fz.smartsense_multi,
+            fz.ias_contact_status_change, fz.ignore_iaszone_change, fz.generic_batteryvoltage_3000_2500,
+        ],
+        toZigbee: [],
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const device = shepherd.find(ieeeAddr, 1);
+            const actions = [
+                (cb) => device.bind('msTemperatureMeasurement', coordinator, cb),
+                (cb) => device.report('msTemperatureMeasurement', 'measuredValue', 300, 600, 1, cb),
+                (cb) => device.bind('genPowerCfg', coordinator, cb),
+                (cb) => device.report('genPowerCfg', 'batteryVoltage', 0, 1000, 0, cb),
+                (cb) => device.write('ssIasZone', 'iasCieAddr', coordinator.device.getIeeeAddr(), cb),
+                (cb) => device.report('ssIasZone', 'zoneStatus', 0, 1000, null, cb),
+                (cb) => device.functional('ssIasZone', 'enrollRsp', {
+                    enrollrspcode: 1,
+                    zoneid: 255,
+                }, cb),
+            ];
+            execute(device, actions, callback);
+        },
+    },
 ];
 
 module.exports = devices.map((device) =>


### PR DESCRIPTION
This PR adds support for the PEQ 3300-P contact sensor.  

I looked it up and centralite manufactured this for PEQ and smartthings seems to treat it the same as the 3300-S.  I tried it out and this config allowed me to add it.