### PR TITLE
Added support for Sinope thermostat custom occupancy and use Herdsman ClusterId and attributes

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -995,11 +995,11 @@ const converters = {
     sinope_thermostat_backlight_autodim_param: {
         key: 'backlight_auto_dim',
         convertSet: async (entity, key, value, meta) => {
-            const sinope_Backlight_Param = {
+            const sinopeBacklightParam = {
                 0: 'on demand',
                 1: 'sensing',
             };
-            const SinopeBacklight = utils.getKeyByValue(sinope_Backlight_Param, value, value);
+            const SinopeBacklight = utils.getKeyByValue(sinopeBacklightParam, value, value);
             await entity.write('hvacThermostat', {SinopeBacklight});
         },
     },

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -981,43 +981,36 @@ const converters = {
     },
 
     // Sinope
+    sinope_thermostat_occupancy: {
+        key: 'thermostat_occupancy',
+        convertSet: async (entity, key, value, meta) => {
+            const sinope_Occupancy = {
+                0: 'unoccupied',
+                1: 'occupied',
+            };
+            const SinopeOccupancy = utils.getKeyByValue(sinope_Occupancy, value, value);
+            await entity.write('hvacThermostat', {SinopeOccupancy});
+        },
+    },
     sinope_thermostat_backlight_autodim_param: {
         key: 'backlight_auto_dim',
         convertSet: async (entity, key, value, meta) => {
-            const sinopeBacklightAutoDimParam = {
+            const sinope_Backlight_Param = {
                 0: 'on demand',
                 1: 'sensing',
             };
-
-            const payload = {
-                0x0402: {
-                    value: utils.getKeyByValue(sinopeBacklightAutoDimParam, value, value),
-                    type: 0x30,
-                },
-            };
-            await entity.write('hvacThermostat', payload, options.hue);
+            const SinopeBacklight = utils.getKeyByValue(sinope_Backlight_Param, value, value);
+            await entity.write('hvacThermostat', {SinopeBacklight});
         },
     },
     sinope_thermostat_enable_outdoor_temperature: {
         key: 'enable_outdoor_temperature',
         convertSet: async (entity, key, value, meta) => {
             if (value.toLowerCase() == 'on') {
-                const payload = {
-                    0x0011: {
-                        value: 10800,
-                        type: 0x21,
-                    },
-                };
-                await entity.write(0xFF01, payload, options.sinope);
+                await entity.write('manuSpecificSinope', {outdoorTempToDisplayTimeout: 10800});
             } else if (value.toLowerCase()=='off') {
-                const payload = {
-                    0x0011: {
-                        // set timer to 30sec in order to disable outdoor temperature
-                        value: 30,
-                        type: 0x21,
-                    },
-                };
-                await entity.write(0xFF01, payload, options.sinope);
+                // set timer to 30sec in order to disable outdoor temperature
+                await entity.write('manuSpecificSinope', {outdoorTempToDisplayTimeout: 30});
             }
         },
     },
@@ -1025,13 +1018,7 @@ const converters = {
         key: 'thermostat_outdoor_temperature',
         convertSet: async (entity, key, value, meta) => {
             if (value > -100 && value < 100) {
-                const payload = {
-                    0x0010: {
-                        value: value * 100,
-                        type: 0x29,
-                    },
-                };
-                await entity.write(0xFF01, payload, options.sinope);
+                await entity.write('manuSpecificSinope', {outdoorTempToDisplay: value * 100});
             }
         },
     },
@@ -1042,22 +1029,10 @@ const converters = {
                 const thermostatDate = new Date();
                 const thermostatTimeSec = thermostatDate.getTime() / 1000;
                 const thermostatTimezoneOffsetSec = thermostatDate.getTimezoneOffset() * 60;
-
-                const payload = {
-                    0x0020: {
-                        value: Math.round(thermostatTimeSec - thermostatTimezoneOffsetSec - 946684800),
-                        type: 0x23,
-                    },
-                };
-                await entity.write(0xFF01, payload, options.sinope);
+                const currentTimeToDisplay = Math.round(thermostatTimeSec - thermostatTimezoneOffsetSec - 946684800);
+                await entity.write('manuSpecificSinope', {currentTimeToDisplay});
             } else if (value !== '') {
-                const payload = {
-                    0x0020: {
-                        value,
-                        type: 0x23,
-                    },
-                };
-                await entity.write(0xFF01, payload, options.sinope);
+                await entity.write('manuSpecificSinope', {currentTimeToDisplay: value});
             }
         },
     },

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -984,11 +984,11 @@ const converters = {
     sinope_thermostat_occupancy: {
         key: 'thermostat_occupancy',
         convertSet: async (entity, key, value, meta) => {
-            const sinope_Occupancy = {
+            const sinopeOccupancy = {
                 0: 'unoccupied',
                 1: 'occupied',
             };
-            const SinopeOccupancy = utils.getKeyByValue(sinope_Occupancy, value, value);
+            const SinopeOccupancy = utils.getKeyByValue(sinopeOccupancy, value, value);
             await entity.write('hvacThermostat', {SinopeOccupancy});
         },
     },

--- a/devices.js
+++ b/devices.js
@@ -4834,11 +4834,11 @@ const devices = [
             fz.thermostat_att_report,
         ],
         toZigbee: [
-            tz.thermostat_local_temperature, tz.thermostat_occupancy,
+            tz.thermostat_local_temperature,
             tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,
             tz.thermostat_temperature_display_mode, tz.thermostat_keypad_lockout,
             tz.thermostat_system_mode, tz.thermostat_running_state,
-            tz.sinope_thermostat_backlight_autodim_param, tz.sinope_thermostat_time,
+            tz.sinope_thermostat_occupancy, tz.sinope_thermostat_backlight_autodim_param, tz.sinope_thermostat_time,
             tz.sinope_thermostat_enable_outdoor_temperature, tz.sinope_thermostat_outdoor_temperature,
         ],
         meta: {configureKey: 1},


### PR DESCRIPTION
Hi this PR depends  on this [PR](https://github.com/Koenkk/zigbee-herdsman/pull/50) in zigbee-herdmans.

It will add custom occupancy for Sinope thermostat. It also simplify all the code using reference to custom cluster listed in ZCL and fix the error that occurs with custom cluster since the switch to zigbee-herdsman.

The thermostats works now with this PR but I could not manage to fix the reporting. The thermostat does not report anything since the use of zigbee-herdsman. Do you have any hint ?

Thank you