### PR TITLE
Added 'Gunnarp 40x40'

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -797,7 +797,7 @@ const devices = [
             execute(device, actions, callback);
         },
     },
-        {
+    {
         zigbeeModel: ['GUNNARP panel 40*40'],
         model: 'T1829',
         description: 'GUNNARP panel 40*40',

--- a/devices.js
+++ b/devices.js
@@ -803,7 +803,7 @@ const devices = [
         description: 'GUNNARP panel 40*40',
         vendor: 'IKEA',
         extend: generic.light_onoff_brightness_colortemp,
-     },
+    },
 
     // Philips
     {

--- a/devices.js
+++ b/devices.js
@@ -797,6 +797,13 @@ const devices = [
             execute(device, actions, callback);
         },
     },
+        {
+        zigbeeModel: ['GUNNARP panel 40*40'],
+        model: 'T1829',
+        description: 'GUNNARP panel 40*40',
+        vendor: 'IKEA',
+        extend: generic.light_onoff_brightness_colortemp,
+     },
 
     // Philips
     {


### PR DESCRIPTION
Seems to work well using just the generic.light_onoff_brightness_colortemp, like with floalt.

Related to:
https://github.com/Koenkk/zigbee-shepherd-converters/issues/659