### PR TITLE
Support for Hue Filament Bulbs

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const debounce = require('debounce');
 const common = require('./common');
 
 const clickLookup = {
@@ -97,20 +96,10 @@ const ictcg1 = (model, msg, publish, options, action) => {
     const payload = {};
 
     if (!store[deviceID]) {
-        const _publish = debounce((msg) => publish(msg), 250);
-        store[deviceID] = {since: false, direction: false, value: 255, publish: _publish};
+        store[deviceID] = {since: false, direction: false, value: 255, publish: publish};
     }
 
     const s = store[deviceID];
-    if (s.since && s.direction) {
-        // Update value
-        const duration = Date.now() - s.since;
-        const delta = Math.round((duration / 10) * (s.direction === 'left' ? -1 : 1));
-        const newValue = s.value + delta;
-        if (newValue >= 0 && newValue <= 255) {
-            s.value = newValue;
-        }
-    }
 
     if (action === 'move') {
         s.since = Date.now();
@@ -122,15 +111,35 @@ const ictcg1 = (model, msg, publish, options, action) => {
             s.value = msg.data.data.level;
             const direction = s.value === 0 ? 'left' : 'right';
             payload.action = `rotate_${direction}_quick`;
+            payload.brightness = s.value;
         } else {
+            const duration = Date.now() - s.since;
+            const delta = Math.round((duration / 10) * (s.direction === 'left' ? -1 : 1));
+            const newValue = s.value + delta;
+            if (newValue >= 0 && newValue <= 255) {
+                s.value = newValue;
+            }
             payload.action = 'rotate_stop';
+            payload.brightness = s.value;
         }
-
-        s.since = false;
-        s.direction = false;
     }
-
-    payload.brightness = s.value;
+    if (s.timerId) {
+        clearInterval(s.timerId);
+        s.timerId = false;
+    }
+    if (action === 'move') {
+        s.timerId = setInterval(() => {
+            const duration = Date.now() - s.since;
+            const delta = Math.round((duration / 10) * (s.direction === 'left' ? -1 : 1));
+            const newValue = s.value + delta;
+            if (newValue >= 0 && newValue <= 255) {
+                s.value = newValue;
+            }
+            payload.brightness = s.value;
+            s.since = Date.now();
+            s.publish(payload);
+        }, 10);
+    }
     s.publish(payload);
 };
 

--- a/devices.js
+++ b/devices.js
@@ -1385,6 +1385,15 @@ const devices = [
         },
     },
     {
+        zigbeeModel: ['DIYRuZ_magnet'],
+        model: 'DIYRuZ_magnet',
+        vendor: 'DIYRuZ',
+        description: '[DIYRuZ contact sensor](https://modkam.ru/?p=1220)',
+        supports: 'contact',
+        fromZigbee: [fz.keypad20_battery, fz.xiaomi_contact],
+        toZigbee: [],
+    },
+    {
         zigbeeModel: ['ZWallRemote0'],
         model: 'ZWallRemote0',
         vendor: 'Custom devices (DiY)',
@@ -3263,6 +3272,13 @@ const devices = [
         vendor: 'Trust',
         description: 'Smart Dimmable LED Bulb',
         extend: generic.light_onoff_brightness,
+    },
+    {
+        zigbeeModel: ['ZLL-ColorTempera'],
+        model: 'ZLED-TUNE9',
+        vendor: 'Trust',
+        description: 'Smart tunable LED bulb',
+        extend: generic.light_onoff_brightness_colortemp,
     },
     {
         zigbeeModel: ['VMS_ADUROLIGHT'],
@@ -5759,6 +5775,24 @@ const devices = [
                     enrollrspcode: 1,
                     zoneid: 255,
                 }, cb),
+            ];
+            execute(device, actions, callback);
+        },
+    },
+
+    // Lonsonho
+    {
+        zigbeeModel: ['Plug_01'],
+        model: '4000116784070',
+        vendor: 'Lonsonho',
+        description: 'Smart plug EU',
+        supports: 'on/off',
+        fromZigbee: [fz.state, fz.ignore_onoff_change],
+        toZigbee: [tz.on_off],
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const device = shepherd.find(ieeeAddr, 11);
+            const actions = [
+                (cb) => device.report('genOnOff', 'onOff', 1, 60, 1, cb),
             ];
             execute(device, actions, callback);
         },

--- a/devices.js
+++ b/devices.js
@@ -5081,6 +5081,23 @@ const devices = [
             execute(device, actions, callback);
         },
     },
+    {
+        zigbeeModel: ['XHS2-SE'],
+        model: 'XHS2-SE',
+        vendor: 'Sercomm',
+        description: 'Magnetic door & window contact sensor',
+        supports: 'contact',
+        fromZigbee: [fz.visonic_contact, fz.ignore_power_change],
+        toZigbee: [],
+        configure: (ieeeAddr, shepherd, coordinator, callback) => {
+            const device = shepherd.find(ieeeAddr, 1);
+            const actions = [
+                (cb) => device.write('ssIasZone', 'iasCieAddr', coordinator.device.getIeeeAddr(), cb),
+                (cb) => device.functional('ssIasZone', 'enrollRsp', {enrollrspcode: 0, zoneid: 0}, cb),
+            ];
+            execute(device, actions, callback);
+        },
+    },
 
     // Leedarson
     {


### PR DESCRIPTION
Today I've got a new filament bulb from Philips Hue. These are the changes necessary for working in Home Assistant. Just cloned another white bulb (9290011370) which just supports dimming and no color temperature. So I hope this is alle necessary. For my Home Assistant environment it works well.

devices.js

{
    zigbeeModel: ['LWV001'],
    model: '929002241201',
    vendor: 'Philips',
    description: 'Hue White Filament Edison E27 LED',
    extend: hue.light_onoff_brightness,
},

homeassistant.js

'929002241201': [configurations.light_brightness],


There are two more bulbs, which maybe are the same Zigbee Model? Somebody else has to check.

{
    zigbeeModel: ['LWV001'],
    model: '929002240901',
    vendor: 'Philips',
    description: 'Hue White Filament E27 LED',
    extend: hue.light_onoff_brightness,
},

{
    zigbeeModel: ['LWV001'],
    model: '929002241401',
    vendor: 'Philips',
    description: 'Hue White Filament Globe E27 LED',
    extend: hue.light_onoff_brightness,
},
