### PR TITLE
Small potential bugfixes

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1470,7 +1470,7 @@ const converters = {
             const voltage = msg.data['batteryVoltage'] * 100;
             return {
                 battery: toPercentage(voltage, battery.min, battery.max),
-                voltage: voltage,
+                voltage: voltage / 1000.0,
             };
         },
     },

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -283,7 +283,8 @@ const converters = {
                 const battery = {max: 3200, min: 2500};
                 const voltage = msg.data['batteryVoltage'] * 100;
                 result.battery = toPercentage(voltage, battery.min, battery.max);
-                result.voltage = voltage;
+                result.voltage = voltage; // @deprecated
+                // result.voltage = voltage / 1000.0;
             }
             if (typeof msg.data['batteryAlarmState'] == 'number') {
                 result.battery_alarm_state = msg.data['batteryAlarmState'];
@@ -345,7 +346,8 @@ const converters = {
             if (voltage) {
                 return {
                     battery: parseFloat(toPercentageCR2032(voltage)),
-                    voltage: voltage,
+                    voltage: voltage, // @deprecated
+                    // voltage: voltage / 1000.0,
                 };
             }
         },
@@ -1470,7 +1472,8 @@ const converters = {
             const voltage = msg.data['batteryVoltage'] * 100;
             return {
                 battery: toPercentage(voltage, battery.min, battery.max),
-                voltage: voltage / 1000.0,
+                voltage: voltage, // @deprecated
+                // voltage: voltage / 1000.0,
             };
         },
     },
@@ -2819,7 +2822,8 @@ const converters = {
             const voltage = msg.data['mainsVoltage'] /10;
             return {
                 battery: toPercentage(voltage, battery.min, battery.max),
-                voltage: voltage,
+                voltage: voltage, // @deprecated
+                // voltage: voltage / 1000.0,
             };
         },
     },

--- a/devices.js
+++ b/devices.js
@@ -2167,7 +2167,7 @@ const devices = [
         supports: 'on/off, power measurement',
         fromZigbee: [fz.SP120_power, fz.state],
         toZigbee: [tz.on_off],
-        meta: {configureKey: 1},
+        meta: {configureKey: 2},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement']);
@@ -2472,7 +2472,7 @@ const devices = [
         supports: 'on/off, power measurement',
         fromZigbee: [fz.state, fz.Z809A_power],
         toZigbee: [tz.on_off],
-        meta: {configureKey: 1},
+        meta: {configureKey: 2},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement']);
@@ -3344,7 +3344,7 @@ const devices = [
         supports: 'on/off',
         fromZigbee: [fz.state, fz.iris_3210L_power],
         toZigbee: [tz.on_off],
-        meta: {configureKey: 2},
+        meta: {configureKey: 3},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement']);
@@ -3455,7 +3455,7 @@ const devices = [
         supports: 'switch and power meter',
         fromZigbee: [fz.state, fz.RZHAC_4256251_power],
         toZigbee: [tz.on_off],
-        meta: {configureKey: 1},
+        meta: {configureKey: 2},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff']);
@@ -3566,7 +3566,7 @@ const devices = [
         vendor: 'HEIMAN',
         fromZigbee: [fz.state, fz.HS2SK_power],
         toZigbee: [tz.on_off],
-        meta: {configureKey: 1},
+        meta: {configureKey: 2},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff']);
@@ -4382,7 +4382,7 @@ const devices = [
         supports: 'on/off, power measurement',
         fromZigbee: [fz.state, fz.peanut_electrical],
         toZigbee: [tz.on_off],
-        meta: {configureKey: 1},
+        meta: {configureKey: 2},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement']);
@@ -4733,7 +4733,7 @@ const devices = [
             fz.meazon_meter,
         ],
         toZigbee: [tz.on_off],
-        meta: {configureKey: 1},
+        meta: {configureKey: 2},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(10);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'seMetering']);
@@ -4760,7 +4760,7 @@ const devices = [
             fz.meazon_meter,
         ],
         toZigbee: [tz.on_off],
-        meta: {configureKey: 1},
+        meta: {configureKey: 2},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(10);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'seMetering']);

--- a/devices.js
+++ b/devices.js
@@ -8,8 +8,8 @@ const store = {};
 const repInterval = {
     MAX: 62000,
     HOUR: 3600,
+    MINUTES_5: 300,
     MINUTE: 60,
-    MINUTES_5: 60,
 };
 
 const bind = async (endpoint, target, clusters) => {


### PR DESCRIPTION
This PR fixes a couple of small bugs that I found while working in the code. Both might need some discussion before this is merged:

1. Changing voltage reported from millivolts to volts: The voltage measurement is converted to millivolts in order to be compared against 3000/2500, but not converted to volts when it is reported. I think that volts is a more natural unit of measure. This has the potential to impact anyone who is already using the voltage measurements, though since this is reported alongside battery percentage, perhaps that wouldn't be many people.

1. `MINUTES_5` constant: the `repInterval` constant for 5 minutes was wrong. Unfortunately, fixing this here does not fix the reporting interval of any already-configured devices, though it doesn't seem to be used by any battery-powered devices, so I'm not sure it's worth reconfiguring them.

What do you think?