### PR TITLE
Increase reportableChange for temperature

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -96,7 +96,7 @@ const configureReporting = {
             attribute: 'measuredValue',
             minimumReportInterval: 0,
             maximumReportInterval: repInterval.HOUR,
-            reportableChange: 0,
+            reportableChange: 25,
         }];
         await endpoint.configureReporting('msTemperatureMeasurement', payload);
     },


### PR DESCRIPTION
Discussion in https://github.com/Koenkk/zigbee2mqtt/issues/2112

This PR  sets the configured `reportableChange` for the temperature attribute to 25, which corresponds to a minimum difference of 0.25ºC. This is being done to reduce battery usage on battery-powered devices that report temperature.