### PR TITLE
Improve support for Iris 3320-L contact sensor

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1477,6 +1477,18 @@ const converters = {
             };
         },
     },
+    battery_3V_2100: {
+        cluster: 'genPowerCfg',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options) => {
+            const battery = {max: 3000, min: 2100};
+            const voltage = msg.data['batteryVoltage'] * 100;
+            return {
+                battery: toPercentage(voltage, battery.min, battery.max),
+                voltage: voltage / 1000.0,
+            };
+        },
+    },
     STS_PRS_251_beeping: {
         cluster: 'genIdentify',
         type: ['attributeReport', 'readResponse'],

--- a/devices.js
+++ b/devices.js
@@ -3375,10 +3375,16 @@ const devices = [
         zigbeeModel: ['3320-L'],
         model: '3320-L',
         vendor: 'Iris',
-        description: 'Contact sensor',
-        supports: 'contact',
-        fromZigbee: [fz.iris_3320L_contact],
+        description: 'Contact and temperature sensor',
+        supports: 'contact and temperature',
+        fromZigbee: [fz.iris_3320L_contact, fz.temperature],
         toZigbee: [],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement']);
+            await configureReporting.temperature(endpoint);
+        },
     },
 
     // ksentry

--- a/devices.js
+++ b/devices.js
@@ -3377,13 +3377,14 @@ const devices = [
         vendor: 'Iris',
         description: 'Contact and temperature sensor',
         supports: 'contact and temperature',
-        fromZigbee: [fz.iris_3320L_contact, fz.temperature],
+        fromZigbee: [fz.iris_3320L_contact, fz.temperature, fz.battery_3V_2100],
         toZigbee: [],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
-            await bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement']);
+            await bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'genPowerCfg']);
             await configureReporting.temperature(endpoint);
+            await configureReporting.batteryVoltage(endpoint);
         },
     },
 


### PR DESCRIPTION
This PR adds battery and temperature reporting to the Lowe's Iris 3320-L contact sensor.

I added a new battery converter to `fromZigbee.js` because from all of the code I've seen (including [this device handler for SmartThings](https://github.com/mitchpond/SmartThingsPublic/blob/master/devicetypes/mitchpond/iris-open-closed-sensor.src/iris-open-closed-sensor.groovy)), the 3V battery should be considered dead at 2.1V, while the existing `battery_3V` converter considers 2.5V to be dead.

I have been testing this code for a couple days with one of my sensors, and it works well. My only complaint (increased battery usage due to minute-by-minute temperature reports) has been addressed in #689.